### PR TITLE
NPI-3060 Remove duplicated epochs in SP3 reader (with warning)

### DIFF
--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -149,11 +149,11 @@ def read_sp3(sp3_path, pOnly=True):
     sp3_df.attrs["path"] = sp3_path
 
     # Check for duplicate epochs, dedupe and log warning
-    duplicated_indexes = sp3_df.index.duplicated()
+    duplicated_indexes = sp3_df.index.duplicated() # Typically sub ms time. Marks all but first instance as duped.
     if duplicated_indexes.sum() > 0: # We have dupes
         first_dupe = sp3_df.index.get_level_values(0)[duplicated_indexes][0]
         logging.warning(
-            f"Duplicate epoch(s) found in SP3! "
+            f"Duplicate epoch(s) found in SP3 ({duplicated_indexes.sum()} additional entries, potentially non-unique). "
             f"First duplicate (as J2000): {first_dupe} (as date): {first_dupe + gn_const.J2000_ORIGIN} "
             f"SP3 path is: '{str(sp3_path)}'. Duplicates will be removed, keeping first."
         )

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -1,3 +1,5 @@
+import logging
+
 """Ephemeris functions"""
 import io as _io
 import os as _os
@@ -12,6 +14,10 @@ from .. import gn_aux as _gn_aux
 from .. import gn_datetime as _gn_datetime
 from .. import gn_io as _gn_io
 from .. import gn_transform as _gn_transform
+
+from .. import gn_const
+
+logger = logging.getLogger(__name__)
 
 _RE_SP3 = _re.compile(rb"^\*(.+)\n((?:[^\*]+)+)", _re.MULTILINE)
 
@@ -141,6 +147,18 @@ def read_sp3(sp3_path, pOnly=True):
 
     sp3_df.attrs["HEADER"] = parsed_header  # writing header data to dataframe attributes
     sp3_df.attrs["path"] = sp3_path
+
+    # Check for duplicate epochs, dedupe and log warning
+    duplicated_indexes = sp3_df.index.duplicated()
+    if duplicated_indexes.sum() > 0: # We have dupes
+        first_dupe = sp3_df.index.get_level_values(0)[duplicated_indexes][0]
+        logging.warning(
+            f"Duplicate epoch(s) found in SP3! "
+            f"First duplicate (as J2000): {first_dupe} (as date): {first_dupe + gn_const.J2000_ORIGIN} "
+            f"SP3 path is: '{str(sp3_path)}'. Duplicates will be removed, keeping first."
+        )
+        sp3_df = sp3_df[~sp3_df.index.duplicated(keep="first")] # Now dedupe them, keeping the first of any clashes
+
     return sp3_df
 
 


### PR DESCRIPTION
Duplicated epochs should **not** be present in SP3 files. A warning is now logged if any are found. Detecting and *removing* duplicates also allows comparisons to be run on less compliant data.

The actual duplicate check is done on the Pandas DataFrame with `Index.duplicated()`. A quick test suggests this executes in less than 1ms on a typical SP3 file, so is not a performance concern.