### PR TITLE
Updated sp3 dupe check \w has_duplicates property

### DIFF
--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -149,8 +149,8 @@ def read_sp3(sp3_path, pOnly=True):
     sp3_df.attrs["path"] = sp3_path
 
     # Check for duplicate epochs, dedupe and log warning
-    duplicated_indexes = sp3_df.index.duplicated() # Typically sub ms time. Marks all but first instance as duped.
-    if duplicated_indexes.sum() > 0: # We have dupes
+    if sp3_df.index.has_duplicates: # a literaly free check
+        duplicated_indexes = sp3_df.index.duplicated() # Typically sub ms time. Marks all but first instance as duped.
         first_dupe = sp3_df.index.get_level_values(0)[duplicated_indexes][0]
         logging.warning(
             f"Duplicate epoch(s) found in SP3 ({duplicated_indexes.sum()} additional entries, potentially non-unique). "


### PR DESCRIPTION
As `has_duplicates` is an already a property inside the sp3 dataframe it is literally free. You may argue that `index.duplicated()` before `if` is not a waste  as you still need it to compute `first dupe`, but I could speculate that 99% of sp3 files come without dupes.