### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,9 +20,9 @@ jobs:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
Could not release due to Node.js deprecation issue. This site suggests the following should work: @v3 --> @v5
https://stackoverflow.com/questions/77897660/node-js-16-actions-are-deprecated-please-update-the-following-actions-to-use-no