### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Previous PR had both set at v5, reading into the previous article again, I might need keep the actions/checkout at v4 instead 
https://stackoverflow.com/questions/77897660/node-js-16-actions-are-deprecated-please-update-the-following-actions-to-use-no 