### PR TITLE
NPI-3197 Transfer download functions from ginan repo

### DIFF
--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -287,9 +287,9 @@ def generate_long_filename(
     analysis_center: str,  # AAA
     content_type: str,  # CNT
     format_type: str,  # FMT
-    start_epoch: _datetime.datetime,
+    start_epoch: _datetime.datetime,  # YYYYDDDHHMM
     end_epoch: _datetime.datetime = None,
-    timespan: _datetime.timedelta = None,
+    timespan: _datetime.timedelta = None,  # LEN
     solution_type: str = "",  # TTT
     sampling_rate: str = "15M",  # SMP
     version: str = "0",  # V
@@ -324,10 +324,11 @@ def generate_long_filename(
 
 
 def long_filename_cddis_cutoff(epoch: _datetime.datetime) -> bool:
+    """Simple function that determines whether long filenames should be expected on the CDDIS server
+
+    :param _datetime.datetime epoch: Start epoch of data in file
+    :return bool: Boolean of whether file would follow long filename convention on CDDIS
     """
-    Simple function that determines whether long filenames should be expected on the CDDIS server
-    """
-    # Long filename cut-off:
     long_filename_cutoff = _datetime.datetime(2022, 11, 27)
     if epoch >= long_filename_cutoff:
         return True

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -341,7 +341,7 @@ def generate_product_filename(
     file_ext: str,
     shift: int = 0,
     long_filename: bool = False,
-    AC: str = "IGS",
+    analysis_center: str = "IGS",
     timespan: _datetime.timedelta = _datetime.timedelta(days=1),
     solution_type: str = "ULT",
     sampling_rate: str = "15M",
@@ -349,9 +349,20 @@ def generate_product_filename(
     project: str = "OPS",
     content_type: str = None,
 ) -> _Tuple[str, GPSDate, _datetime.datetime]:
-    """
-    Generate filename, GPSDate obj from datetime
-    Optionally, move reference_start forward by "shift" hours
+    """Given a reference datetime and extention of file, generate the IGS filename and GPSDate obj for use in download
+
+    :param _datetime.datetime reference_start: Datetime of the start period of interest
+    :param str file_ext: Extention of the file (e.g. SP3, SNX, ERP, etc)
+    :param int shift: Shift the reference time by "shift" hours (in filename and GPSDate output), defaults to 0
+    :param bool long_filename: Use the IGS long filename convention, defaults to False
+    :param str analysis_center: Desired analysis center for filename output, defaults to "IGS"
+    :param _datetime.timedelta timespan: Span of the file as datetime obj, defaults to _datetime.timedelta(days=1)
+    :param str solution_type: Solution type for the filename, defaults to "ULT"
+    :param str sampling_rate: Sampling rate of data for the filename, defaults to "15M"
+    :param str version: Version of the file, defaults to "0"
+    :param str project: IGS project descriptor, defaults to "OPS"
+    :param str content_type: IGS content specifier - if None set automatically based on file_ext, defaults to None
+    :return _Tuple[str, GPSDate, _datetime.datetime]: Tuple of filename str, GPSDate and datetime obj (based on shift)
     """
     reference_start += _datetime.timedelta(hours=shift)
     if type(reference_start == _datetime.date):
@@ -361,10 +372,10 @@ def generate_product_filename(
 
     if long_filename:
         if content_type == None:
-            content_type = generate_content_type(file_ext, analysis_center=AC)
+            content_type = generate_content_type(file_ext, analysis_center=analysis_center)
         product_filename = (
             generate_long_filename(
-                analysis_center=AC,
+                analysis_center=analysis_center,
                 content_type=content_type,
                 format_type=file_ext,
                 start_epoch=reference_start,

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -211,11 +211,6 @@ def gen_prod_filename(dt, pref, suff, f_type, wkly_file=False, repro3=False):
         f = f"{pref}{gpswkD}{suff}.{f_type}.Z"
     return f, gpswk
 
-    """
-    Name of uncompressed filename given the [assumed compressed] filename (filename).
-    If not one of the recognized compression format types, return original filename -
-    """
-
 
 def generate_uncompressed_filename(filename: str) -> str:
     """Returns a string of the uncompressed filename given the [assumed compressed] filename
@@ -262,9 +257,6 @@ def generate_content_type(file_ext: str, analysis_center: str) -> str:
     if isinstance(content_type, dict):
         content_type = content_type.get(analysis_center, content_type.get(None))
     return content_type
-    """
-    Generate the 3-char LEN for IGS filename based on the start and end epochs passed in
-    """
 
 
 def generate_nominal_span(start_epoch: _datetime.datetime, end_epoch: _datetime.datetime) -> str:
@@ -303,11 +295,19 @@ def generate_long_filename(
     version: str = "0",  # V
     project: str = "EXP",  # PPP, e.g. EXP, OPS
 ) -> str:
-    """
-    Function to generate filename with IGS Long Product Filename convention (v1.0) as outlined in
-    http://acc.igs.org/repro3/Long_Product_Filenames_v1.0.pdf
+    """Generate filename following the IGS Long Product Filename convention: AAAVPPPTTT_YYYYDDDHHMM_LEN_SMP_CNT.FMT[.gz]
 
-    AAAVPPPTTT_YYYYDDDHHMM_LEN_SMP_CNT.FMT[.gz]
+    :param str analysis_center: 3-char string identifier for Analysis Center
+    :param str content_type: 3-char string identifier for Content Type of the file
+    :param str format_type: 3-char string identifier for Format Type of the file
+    :param _datetime.datetime start_epoch: Start epoch of data
+    :param _datetime.datetime end_epoch: End epoch of data [Optional: can be determined from timespan], defaults to None
+    :param _datetime.timedelta timespan: Timespan of data in file (Start to End epoch), defaults to None
+    :param str solution_type: 3-char string identifier for Solution Type of file, defaults to ""
+    :param str sampling_rate: 3-char string identifier for Sampling Rate of the file, defaults to "15M"
+    :param str version: 3-char string identifier for Version of the file
+    :param str project: 3-char string identifier for Project Type of the file
+    :return str: The IGS long filename given all inputs
     """
     initial_epoch = start_epoch.strftime("%Y%j%H%M")
     if end_epoch == None:

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -216,7 +216,7 @@ def generate_uncompressed_filename(filename: str) -> str:
     """Returns a string of the uncompressed filename given the [assumed compressed] filename
 
     :param str filename: Original filename of compressed file
-    :return str: Returns the filename of what the uncompressed file
+    :return str: The uncompressed filename based on input (returns input filename if compression not recognised)
     """
     if filename.endswith(".tar.gz") or filename.endswith(".tar"):
         with _tarfile.open(filename, "r") as tar:
@@ -265,7 +265,7 @@ def generate_nominal_span(start_epoch: _datetime.datetime, end_epoch: _datetime.
     :param _datetime.datetime start_epoch: Start epoch of data in file
     :param _datetime.datetime end_epoch: End epoch of data in file
     :raises NotImplementedError: Raise error if range cannot be generated
-    :return str: Returns the 3-char string corresponding to the LEN or span of the data for IGS long filename
+    :return str: The 3-char string corresponding to the LEN or span of the data for IGS long filename
     """
     span = (end_epoch - start_epoch).total_seconds()
     if span % 86400 == 0.0:

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -211,11 +211,17 @@ def gen_prod_filename(dt, pref, suff, f_type, wkly_file=False, repro3=False):
         f = f"{pref}{gpswkD}{suff}.{f_type}.Z"
     return f, gpswk
 
-
-def generate_uncompressed_filename(filename: str) -> str:
     """
     Name of uncompressed filename given the [assumed compressed] filename (filename).
     If not one of the recognized compression format types, return original filename -
+    """
+
+
+def generate_uncompressed_filename(filename: str) -> str:
+    """Returns a string of the uncompressed filename given the [assumed compressed] filename
+
+    :param str filename: Original filename of compressed file
+    :return str: Returns the filename of what the uncompressed file
     """
     if filename.endswith(".tar.gz") or filename.endswith(".tar"):
         with _tarfile.open(filename, "r") as tar:
@@ -235,9 +241,11 @@ def generate_uncompressed_filename(filename: str) -> str:
 
 
 def generate_content_type(file_ext: str, analysis_center: str) -> str:
-    """
-    IGS files following the long filename convention require a content specifier
-    Given the file extension, generate the content specifier
+    """Given the file extension, generate the content specifier following the IGS long filename convention
+
+    :param str file_ext: 3-char file extension to generate the content specifier for
+    :param str analysis_center: 3-char Analysis centre that produced the file
+    :return str: 3-char content specifier string
     """
     file_ext = file_ext.upper()
     file_ext_dict = {
@@ -254,11 +262,18 @@ def generate_content_type(file_ext: str, analysis_center: str) -> str:
     if isinstance(content_type, dict):
         content_type = content_type.get(analysis_center, content_type.get(None))
     return content_type
-
-
-def generate_nominal_span(start_epoch: datetime, end_epoch: datetime) -> str:
     """
-    Generate the 3 character LEN for IGS filename based on the start and end epochs passed in
+    Generate the 3-char LEN for IGS filename based on the start and end epochs passed in
+    """
+
+
+def generate_nominal_span(start_epoch: _datetime.datetime, end_epoch: _datetime.datetime) -> str:
+    """Generate the 3-char LEN or span following the IGS long filename convention given the start and end epochs
+
+    :param _datetime.datetime start_epoch: Start epoch of data in file
+    :param _datetime.datetime end_epoch: End epoch of data in file
+    :raises NotImplementedError: Raise error if range cannot be generated
+    :return str: Returns the 3-char string corresponding to the LEN or span of the data for IGS long filename
     """
     span = (end_epoch - start_epoch).total_seconds()
     if span % 86400 == 0.0:

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -33,7 +33,7 @@ import numpy as _np
 import pandas as _pd
 from boto3.s3.transfer import TransferConfig
 
-from .gn_datetime import GPSDate, dt2gpswk, gpsweekD, gpswkD2dt
+from .gn_datetime import GPSDate, dt2gpswk, gpswkD2dt
 
 MB = 1024 * 1024
 
@@ -627,7 +627,6 @@ def check_n_download(comp_filename, dwndir, ftps, uncomp=True, remove_comp_file=
     """Download compressed file to dwndir if not already present and optionally uncompress"""
 
     success = False
-
     comp_file = _Path(dwndir + comp_filename)
 
     if dwndir[-1] != "/":
@@ -643,12 +642,9 @@ def check_n_download(comp_filename, dwndir, ftps, uncomp=True, remove_comp_file=
             logging.debug(f"Downloaded and uncompressed {comp_filename}")
         else:
             logging.debug(f"Downloaded {comp_filename}")
-
         success = True
-
     else:
         success = True
-
     return success
 
 

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -14,6 +14,7 @@ import logging
 import os as _os
 import random as _random
 import shutil
+import click as _click
 import sys as _sys
 import threading
 import time as _time
@@ -415,7 +416,7 @@ def check_whether_to_download(
     # Check if file already exists - if so, then re-download or not based on if_file_present value
     if output_path.is_file():
         if if_file_present == "prompt_user":
-            replace = click.confirm(
+            replace = _click.confirm(
                 f"File {output_path} already present; download and replace? - Answer:", default=None
             )
             if replace:

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -5,6 +5,7 @@ erp
 clk
 rnx (including transformation from crx to rnx)
 """
+
 import concurrent as _concurrent
 from contextlib import contextmanager as _contextmanager
 import datetime as _datetime
@@ -13,7 +14,6 @@ import logging
 import os as _os
 import random as _random
 import shutil
-import subprocess as _subprocess
 import sys as _sys
 import threading
 import time as _time
@@ -21,9 +21,10 @@ import gzip as _gzip
 import tarfile as _tarfile
 import hatanaka as _hatanaka
 import ftplib as _ftplib
+import sleep as _sleep
 from ftplib import FTP_TLS as _FTP_TLS
 from pathlib import Path as _Path
-from typing import Optional as _Optional, Union as _Union
+from typing import Optional as _Optional, Union as _Union, Tuple as _Tuple
 from urllib import request as _request
 from urllib.error import HTTPError as _HTTPError
 
@@ -32,7 +33,7 @@ import numpy as _np
 import pandas as _pd
 from boto3.s3.transfer import TransferConfig
 
-from .gn_datetime import dt2gpswk, gpsweekD, gpswkD2dt
+from .gn_datetime import GPSDate, dt2gpswk, gpsweekD, gpswkD2dt
 
 MB = 1024 * 1024
 
@@ -211,6 +212,267 @@ def gen_prod_filename(dt, pref, suff, f_type, wkly_file=False, repro3=False):
     return f, gpswk
 
 
+def generate_uncompressed_filename(filename: str) -> str:
+    """
+    Name of uncompressed filename given the [assumed compressed] filename (filename).
+    If not one of the recognized compression format types, return original filename -
+    """
+    if filename.endswith(".tar.gz") or filename.endswith(".tar"):
+        with _tarfile.open(filename, "r") as tar:
+            # Get name of file inside tar.gz file (assuming only one file)
+            return tar.getmembers()[0].name
+    elif filename.endswith(".crx.gz"):
+        return filename[:-6] + "rnx"
+    elif filename.endswith(".gz"):
+        return filename[:-3]
+    elif filename.endswith(".Z"):
+        return filename[:-2]
+    elif filename.endswith(".bz2"):
+        return filename[:-4]
+    else:
+        logging.debug(f"{filename} not compressed - extension not a recognized compression format")
+        return filename
+
+
+def generate_content_type(file_ext: str, analysis_center: str) -> str:
+    """
+    IGS files following the long filename convention require a content specifier
+    Given the file extension, generate the content specifier
+    """
+    file_ext = file_ext.upper()
+    file_ext_dict = {
+        "ERP": "ERP",
+        "SP3": "ORB",
+        "CLK": "CLK",
+        "OBX": "ATT",
+        "TRO": "TRO",
+        "SNX": "CRD",
+        "BIA": {"ESA": "BIA", None: "OSB"},
+    }
+    content_type = file_ext_dict.get(file_ext)
+    # If result is still dictionary, use analysis_center to determine content_type
+    if isinstance(content_type, dict):
+        content_type = content_type.get(analysis_center, content_type.get(None))
+    return content_type
+
+
+def generate_nominal_span(start_epoch: datetime, end_epoch: datetime) -> str:
+    """
+    Generate the 3 character LEN for IGS filename based on the start and end epochs passed in
+    """
+    span = (end_epoch - start_epoch).total_seconds()
+    if span % 86400 == 0.0:
+        unit = "D"
+        span = int(span // 86400)
+    elif span % 3600 == 0.0:
+        unit = "H"
+        span = int(span // 3600)
+    elif span % 60 == 0.0:
+        unit = "M"
+        span = int(span // 60)
+    else:
+        raise NotImplementedError
+
+    return f"{span:02}{unit}"
+
+
+def generate_long_filename(
+    analysis_center: str,  # AAA
+    content_type: str,  # CNT
+    format_type: str,  # FMT
+    start_epoch: _datetime.datetime,
+    end_epoch: _datetime.datetime = None,
+    timespan: _datetime.timedelta = None,
+    solution_type: str = "",  # TTT
+    sampling_rate: str = "15M",  # SMP
+    version: str = "0",  # V
+    project: str = "EXP",  # PPP, e.g. EXP, OPS
+) -> str:
+    """
+    Function to generate filename with IGS Long Product Filename convention (v1.0) as outlined in
+    http://acc.igs.org/repro3/Long_Product_Filenames_v1.0.pdf
+
+    AAAVPPPTTT_YYYYDDDHHMM_LEN_SMP_CNT.FMT[.gz]
+    """
+    initial_epoch = start_epoch.strftime("%Y%j%H%M")
+    if end_epoch == None:
+        end_epoch = start_epoch + timespan
+    timespan_str = generate_nominal_span(start_epoch, end_epoch)
+
+    result = (
+        f"{analysis_center}{version}{project}"
+        f"{solution_type}_"
+        f"{initial_epoch}_{timespan_str}_{sampling_rate}_"
+        f"{content_type}.{format_type}"
+    )
+    return result
+
+
+def long_filename_cddis_cutoff(epoch: _datetime.datetime) -> bool:
+    """
+    Simple function that determines whether long filenames should be expected on the CDDIS server
+    """
+    # Long filename cut-off:
+    long_filename_cutoff = _datetime.datetime(2022, 11, 27)
+    if epoch >= long_filename_cutoff:
+        return True
+    else:
+        return False
+
+
+def generate_product_filename(
+    reference_start: _datetime.datetime,
+    file_ext: str,
+    shift: int = 0,
+    long_filename: bool = False,
+    AC: str = "IGS",
+    timespan: _datetime.timedelta = _datetime.timedelta(days=1),
+    solution_type: str = "ULT",
+    sampling_rate: str = "15M",
+    version: str = "0",
+    project: str = "OPS",
+    content_type: str = None,
+) -> _Tuple[str, GPSDate, _datetime.datetime]:
+    """
+    Generate filename, GPSDate obj from datetime
+    Optionally, move reference_start forward by "shift" hours
+    """
+    reference_start += _datetime.timedelta(hours=shift)
+    if type(reference_start == _datetime.date):
+        gps_date = GPSDate(str(reference_start))
+    else:
+        gps_date = GPSDate(str(reference_start.date()))
+
+    if long_filename:
+        if content_type == None:
+            content_type = generate_content_type(file_ext, analysis_center=AC)
+        product_filename = (
+            generate_long_filename(
+                analysis_center=AC,
+                content_type=content_type,
+                format_type=file_ext,
+                start_epoch=reference_start,
+                timespan=timespan,
+                solution_type=solution_type,
+                sampling_rate=sampling_rate,
+                version=version,
+                project=project,
+            )
+            + ".gz"
+        )
+    else:
+        if file_ext.lower() == "snx":
+            product_filename = f"igs{gps_date.yr[2:]}P{gps_date.gpswk}.snx.Z"
+        else:
+            hour = f"{reference_start.hour:02}"
+            product_filename = f"igu{gps_date.gpswkD}_{hour}.{file_ext}.Z"
+    return product_filename, gps_date, reference_start
+
+
+def check_whether_to_download(
+    filename: str, download_dir: _Path, if_file_present: str = "prompt_user"
+) -> _Union[_Path, None]:
+    """Determine whether to download given file (filename) to the desired location (download_dir) based on whether it is
+    already present and what action to take if it is (if_file_present)
+
+    :param str filename: Filename of the downloaded file
+    :param _Path download_dir: Path obj to download directory
+    :param str if_file_present: How to handle files that are already present ["replace","dont_replace","prompt_user"], defaults to "prompt_user"
+    :return _Union[_Path, None]: Path obj to the downloaded file if file should be downloaded, otherwise returns None
+    """
+    # Flag to determine whether to download:
+    download = None
+    # Create Path obj to where file will be - if original file is compressed, check for decompressed file
+    uncompressed_filename = generate_uncompressed_filename(filename)  # Returns original filename if not compressed
+    output_path = download_dir / uncompressed_filename
+    # Check if file already exists - if so, then re-download or not based on if_file_present value
+    if output_path.is_file():
+        if if_file_present == "prompt_user":
+            replace = click.confirm(
+                f"File {output_path} already present; download and replace? - Answer:", default=None
+            )
+            if replace:
+                logging.info(f"Option chosen: Replace. Re-downloading {output_path.name} to {download_dir}")
+                download = True
+            else:
+                logging.info(f"Option chosen: Don't Replace. Leaving {output_path.name} as is in {download_dir}")
+                download = False
+        elif if_file_present == "dont_replace":
+            logging.info(f"File {output_path} already present; Flag --dont-replace is on ... skipping download ...")
+            download = False
+        elif if_file_present == "replace":
+            logging.info(
+                f"File {output_path} already present; Flag --replace is on ... re-downloading to {download_dir}"
+            )
+            download = True
+    else:
+        download = True
+
+    if download == False:
+        return None
+    elif download == True:
+        if uncompressed_filename == filename:  # Existing Path obj is already the one we need to download
+            return output_path
+        else:
+            return download_dir / filename  # Path to compressed file to download
+    elif download == None:
+        logging.error(f"Invalid internal flag value for if_file_present: '{if_file_present}'")
+
+
+def attempt_ftps_download(
+    download_dir: _Path,
+    ftps: _ftplib.FTP_TLS,
+    filename: str,
+    type_of_file: str = None,
+    if_file_present: str = "prompt_user",
+) -> _Path:
+    """Attempt download of file (filename) given the ftps client object (ftps) to chosen location (download_dir)
+
+    :param _Path download_dir: Path obj to download directory
+    :param _ftplib.FTP_TLS ftps: FTP_TLS client pointed at download source
+    :param str filename: Filename to assign for the downloaded file
+    :param str type_of_file: How to label the file for STDOUT messages, defaults to None
+    :param str if_file_present: How to handle files that are already present ["replace","dont_replace","prompt_user"], defaults to "prompt_user"
+    :return _Path: Path obj to the downloaded file
+    """
+    ""
+    logging.info(f"Attempting FTPS Download of {type_of_file} file - {filename} to {download_dir}")
+    download_filepath = check_whether_to_download(
+        filename=filename, download_dir=download_dir, if_file_present=if_file_present
+    )
+    if download_filepath:
+        logging.debug(f"Downloading {filename}")
+        with open(download_filepath, "wb") as local_file:
+            ftps.retrbinary(f"RETR {filename}", local_file.write)
+
+    return download_filepath
+
+
+def attempt_url_download(
+    download_dir: _Path, url: str, filename: str = None, type_of_file: str = None, if_file_present: str = "prompt_user"
+) -> _Path:
+    """Attempt download of file given URL (url) to chosen location (download_dir)
+
+    :param Path download_dir: Path obj to download directory
+    :param str url: URL to download
+    :param str filename: Filename to assign for the downloaded file, defaults to None
+    :param str type_of_file: How to label the file for STDOUT messages, defaults to None
+    :param str if_file_present: How to handle files that are already present ["replace","dont_replace","prompt_user"], defaults to "prompt_user"
+    :return Path: Path obj to the downloaded file
+    """
+    # If the filename is not provided, use the filename from the URL
+    if not filename:
+        filename = url[url.rfind("/") + 1 :]
+    logging.info(f"Attempting URL Download of {type_of_file} file - {filename} to {download_dir}")
+    # Use the check_whether_to_download function to determine whether to download the file
+    download_filepath = check_whether_to_download(
+        filename=filename, download_dir=download_dir, if_file_present=if_file_present
+    )
+    if download_filepath:
+        download_url(url, download_filepath)
+    return download_filepath
+
+
 def dates_type_convert(dates):
     """Convert the input variable (dates) to a list of datetime objects"""
     typ_dt = type(dates)
@@ -334,8 +596,10 @@ def check_n_download_url(url, dwndir, filename=False):
         download_url(url, out_f)
 
 
-def check_n_download(comp_filename, dwndir, ftps, uncomp=True, remove_crx=False, no_check=False):
+def check_n_download(comp_filename, dwndir, ftps, uncomp=True, remove_comp_file=False, no_check=False):
     """Download compressed file to dwndir if not already present and optionally uncompress"""
+
+    success = False
 
     comp_file = _Path(dwndir + comp_filename)
 
@@ -348,59 +612,17 @@ def check_n_download(comp_filename, dwndir, ftps, uncomp=True, remove_crx=False,
         with open(comp_file, "wb") as local_f:
             ftps.retrbinary(f"RETR {comp_filename}", local_f.write)
         if uncomp:
-            _subprocess.run(["uncompress", f"{comp_file}"])
-            # If RINEX file, need to convert from Hatanaka compression
-            if comp_filename.endswith(".crx.gz"):
-                get_install_crx2rnx()
-                crx_file = _Path(dwndir + comp_filename[:-3])
-                if _sys.path[0][-1] == "/":
-                    run_str = f"{_sys.path[0]}crx2rnx"
-                else:
-                    run_str = f"{_sys.path[0]}/crx2rnx"
-                _subprocess.run([run_str, f"{str(crx_file)}"])
-
+            decompress_file(comp_file, delete_after_decompression=remove_comp_file)
             logging.debug(f"Downloaded and uncompressed {comp_filename}")
         else:
             logging.debug(f"Downloaded {comp_filename}")
 
-        if remove_crx:
-            if comp_filename.endswith(".crx.gz"):
-                crx_file.unlink()
         success = True
-        # except:
-        #     print(f'Failed to download {comp_filename}')
-        #     success=False
+
     else:
         success = True
 
     return success
-
-
-def get_install_crx2rnx(override=False, verbose=False):
-    """
-    Check for presence of crx2rnx in PATH.
-    If not present, download and extract to python environment PATH location.
-    If override = True, will download if present or not
-    """
-    if (not _Path(f"{_sys.path[0]}/crx2rnx").is_file()) or (override):
-        if verbose:
-            logging.info(f"Installing crx2rnx at {_sys.path[0]}")
-        tmp_dir = _Path("tmp")
-        if not tmp_dir.is_dir():
-            tmp_dir.mkdir()
-
-        url = "https://terras.gsi.go.jp/ja/crx2rnx/RNXCMP_4.0.8_src.tar.gz"
-        out_f = _Path("tmp/RNXCMP_4.0.8_src.tar.gz")
-        _request.urlretrieve(url, out_f)
-
-        _subprocess.run(["tar", "-xvf", "tmp/RNXCMP_4.0.8_src.tar.gz", "-C", "tmp"])
-        cp = ["gcc", "-ansi", "-O2", "-static", "tmp/RNXCMP_4.0.8_src/source/crx2rnx.c", "-o", "crx2rnx"]
-        _subprocess.run(cp)
-        _subprocess.run(["rm", "-r", "tmp"])
-        _subprocess.run(["mv", "crx2rnx", _sys.path[0]])
-    else:
-        if verbose:
-            logging.info(f"crx2rnx already present in {_sys.path[0]}")
 
 
 # TODO: Deprecate in favour of the contextmanager?
@@ -575,6 +797,58 @@ def download_file_from_cddis(
                 logging.debug(f"Received an error ({e}) while try to download {filename}, retrying({retries}).")
                 # Add some backoff time (exponential random as it appears to be contention based?)
                 _time.sleep(_random.uniform(0.0, 2.0**retries))
+
+
+def download_file_from_cddis(
+    filename: str,
+    ftp_folder: str,
+    output_folder: _Path,
+    max_retries: int = 3,
+    decompress: bool = True,
+    if_file_present: str = "prompt_user",
+    note_filetype: str = None,
+) -> None:
+    """Downloads a single file from the cddis ftp server.
+
+    :param filename: Name of the file to download
+    :ftp_folder: Folder where the file is stored on the remote
+    :output_folder: Folder to store the output file
+    :ftps: Optional active connection object which is reused
+    :max_retries: Number of retries before raising error
+    :uncomp: If true, uncompress files on download
+    """
+    with ftp_tls("gdc.cddis.eosdis.nasa.gov") as ftps:
+        ftps.cwd(ftp_folder)
+        retries = 0
+        download_done = False
+        while not download_done and retries <= max_retries:
+            try:
+                download_filepath = attempt_ftps_download(
+                    download_dir=output_folder,
+                    ftps=ftps,
+                    filename=filename,
+                    type_of_file=note_filetype,
+                    if_file_present=if_file_present,
+                )
+                if decompress and download_filepath:
+                    download_filepath = decompress_file(
+                        input_filepath=download_filepath, delete_after_decompression=True
+                    )
+                download_done = True
+                if download_filepath:
+                    logging.info(f"Downloaded {download_filepath.name}")
+            except _ftplib.all_errors as e:
+                retries += 1
+                if retries > max_retries:
+                    logging.info(f"Failed to download {filename} and reached maximum retry count ({max_retries}).")
+                    if (output_folder / filename).is_file():
+                        (output_folder / filename).unlink()
+                    raise e
+
+                logging.debug(f"Received an error ({e}) while try to download {filename}, retrying({retries}).")
+                # Add some backoff time (exponential random as it appears to be contention based?)
+                _sleep(_random.uniform(0.0, 2.0**retries))
+    return download_filepath
 
 
 def download_multiple_files_from_cddis(files: [str], ftp_folder: str, output_folder: _Path) -> None:


### PR DESCRIPTION
Recently we had an update to the auto_download_PPP.py script over on the Ginan repo. A number of new and useful functions were added there but have a more appropriate home here on `gnssanalysis`. 

This PR transfers some of those useful functions from https://github.com/GeoscienceAustralia/ginan/blob/develop-weekly/scripts/auto_download_PPP.py to`gn_download.py`.

This should be the first in a series of PRs where we slowly move to using the newer download functions. This will include: 
- moving existing utilities that use the old download functions to using the new functions (on gnssanalysis and ginan)
- deleting old functions that have been superseded with new functions
- updating / documenting existing functions that aren't deleted

Happy to discuss this further in the comments of this PR or in the discussions tab of this repo