### PR TITLE
Correct SISRE calculation

### DIFF
--- a/gnssanalysis/gn_diffaux.py
+++ b/gnssanalysis/gn_diffaux.py
@@ -500,7 +500,7 @@ def sisre(
     alpha, beta = _np.vsplit(coeffs_df.values, indices_or_sections=2)
 
     sisre = _pd.DataFrame(
-        data=_np.sqrt((alpha * radial + clk_diff) ** 2 + (along**2 + cross**2) / beta),
+        data=_np.sqrt((alpha * radial - _gn_const.C_LIGHT * clk_diff) ** 2 + (along**2 + cross**2) / beta),
         index=rac_unstack.index,
         columns=rac_unstack.Radial.columns,
     )


### PR DESCRIPTION
Dear gnssanalysis developers, hello! Thank you for your work.

We noticed that there seems to be some errors in the function used to calculate SISRE in the `gn_diffaux.py` file of gnssanalysis. We believe that when calculating the SISRE indicator, `clk_diff` should be multiplied by the speed of light and mutually offset with the radial orbit deviation.

We have corrected this issue. If you think our correction is correct, please accept our PR. If there are any questions, please give us feedback.