### PR TITLE
Fix errors in RINEX reading function

### DIFF
--- a/gnssanalysis/gn_datetime.py
+++ b/gnssanalysis/gn_datetime.py
@@ -195,12 +195,6 @@ def datetime2gpsweeksec(array: _np.ndarray, as_decimal=False) -> _Union[tuple, _
 
 def datetime2j2000(datetime: _np.ndarray) -> _np.ndarray:
     """datetime64 conversion to int seconds after J2000 (2000-01-01 12:00:00)"""
-    if not isinstance(datetime, (_np.ndarray, _np.datetime64)):
-        raise TypeError("input should be numpy ndarray or single datetime64 value")
-    if datetime.dtype != "<M8[s]":
-        return (datetime.astype("datetime64[s]") - _gn_const.J2000_ORIGIN).astype(
-            int
-        )  # this will break on pandas dataframe
     return (datetime.astype("datetime64[s]") - _gn_const.J2000_ORIGIN).astype(int)
 
 

--- a/gnssanalysis/gn_io/rinex.py
+++ b/gnssanalysis/gn_io/rinex.py
@@ -68,8 +68,11 @@ def _read_rnx(rnx_path):
 
     buf = []
     for constellation_code, (signal_counts, signal_headers) in constellation_signals.items():
-        gnss_rnx_df = rnx_df[(prn_code == constellation_code)][0:(signal_counts-1)].copy()
-        gnss_rnx_df.columns = _pd.MultiIndex.from_product([signal_headers, ["EST", "STRG"]])
+        gnss_rnx_df = rnx_df[(prn_code == constellation_code)].copy()
+        trailing_column_count = len(rnx_df.columns) // 2 - signal_counts
+        padded_signal_headers = signal_headers + list(range(trailing_column_count))
+        gnss_rnx_df.columns = _pd.MultiIndex.from_product([padded_signal_headers, ["EST", "STRG"]])
+        gnss_rnx_df.dropna(axis="columns", how="all", )
         buf.append(gnss_rnx_df)
     return _pd.concat(buf, keys=constellation_signals.keys(), axis=0)
 

--- a/gnssanalysis/gn_io/rinex.py
+++ b/gnssanalysis/gn_io/rinex.py
@@ -72,7 +72,7 @@ def _read_rnx(rnx_path):
         trailing_column_count = len(rnx_df.columns) // 2 - signal_counts
         padded_signal_headers = signal_headers + list(range(trailing_column_count))
         gnss_rnx_df.columns = _pd.MultiIndex.from_product([padded_signal_headers, ["EST", "STRG"]])
-        gnss_rnx_df.dropna(axis="columns", how="all", )
+        gnss_rnx_df.dropna(axis="columns", how="all", inplace=True)
         buf.append(gnss_rnx_df)
     return _pd.concat(buf, keys=constellation_signals.keys(), axis=0)
 


### PR DESCRIPTION
The existing rinex reading functions unfortunately atrophied over time and there was an failure in the line that extracted the expected column count from the signal header information (maybe due to changes in pandas versions) and then also failed using datetime2j2000 due to the runtime type checking in that function.
I reworked the column detection and then removed the type checking in the datetime2j2000 function (that function still might need love and updated type hints but I started by just deleting the branching because it seemed to have the same code on both branches).
This go the function working on the data I originally cared about but testing on further random data revealed it failed for /LGOW00AUS_S_20212590000_01D_30S_MO.rnx obtained from GA's gnss-data and more generally wouldn't work for any RINEX file with more than two lines of signals in the header.
I entirely reworked the way the header reading code works and I think simplified it overall. I also did a little tidy-up in the code generally and it seems to work for a large random sampling of rinex (3) files pulled from gnss-data.
This code still doesn't handle rinex 2, it is a bit brittle in places, and a little funky and maybe slow in implementation (it does a lot of weird fiddling with strings to do the parsing process and I think it can probably all be replaced with block-by-block read_fwf with some post-processing) but it's better than it started.