### PR TITLE
Convert datetimes explicitly to int64 not int

### DIFF
--- a/gnssanalysis/gn_io/pod.py
+++ b/gnssanalysis/gn_io/pod.py
@@ -14,7 +14,7 @@ def pod_get_IC_dt(pod_out: bytes) -> int:
     end = pod_out.find(b"\n", begin)
     date = _pd.Series(pod_out[begin:end].strip().decode()).str.split(pat=r"\s+")
     year, month, day, frac = date.tolist()[0]
-    dt_value = (_np.datetime64("-".join([year, month.zfill(2), day])) - _gn_const.J2000_ORIGIN).astype(int)
+    dt_value = (_np.datetime64("-".join([year, month.zfill(2), day])) - _gn_const.J2000_ORIGIN).astype("int64")
     return dt_value + int(86400 * float(frac))
 
 


### PR DESCRIPTION
On at least one platform (Windows I think) I've seen while working with someone else  `int` can be a 32-bit integer and the conversion from numpy datetime64/timedelta64 objects fail to convert to 32-bit integers (fair enough due to overflow possibilities). But we don't care about the size of the integer, we just want the conversion to work, and so I've changed to explicitly converting to 64-bit integers.
There's generally also some suspicious stuff going on in gn_datetime but I didn't bother looking at it at this stage, just making the minimal changes needed at this stage.