### PR TITLE
Npi 3430 Fix SP3 header parsing to more robustly handle orbit accuracy values

### DIFF
--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -25,10 +25,13 @@ _RE_SP3_HEAD = _re.compile(
                                     (\w+)(?:[ ]+(\w+)|)""",
     _re.VERBOSE,
 )
-# SV names. multiline, findall
+# Regex to extract Satellite Vehicle (SV) names (E.g. G02). Regex options/flags: multiline, findall
 _RE_SP3_HEAD_SV = _re.compile(rb"^\+[ ]+(?:[\d]+|)[ ]+((?:[A-Z]\d{2})+)\W", _re.MULTILINE)
-# orbits accuracy codes
-_RE_SP3_ACC = _re.compile(rb"^\+{2}[ ]+([\d\s]{50}\d)\W", _re.MULTILINE)
+
+# Regex for orbits accuracy codes (E.g. ' 15' - space padded, blocks are three chars wide).
+# Note: header is padded with '  0' entries after the actual data, so empty fields are matched and then trimmed.
+_RE_SP3_ACC = _re.compile(rb"^\+{2}[ ]+([\d\s]{51})$", _re.MULTILINE)
+
 # File descriptor and clock
 _RE_SP3_HEAD_FDESCR = _re.compile(rb"\%c[ ]+(\w{1})[ ]+cc[ ](\w{3})")
 


### PR DESCRIPTION
Previous implementation searched for a slightly incorrect length of data (50 instead of 51 chars), and did this instead of explicitly specifying the expected format (three char chunks which always end with a digit). It also did not allow for `-`, leading negative values to crash the SP3 header parser.