### PR TITLE
ZTD cpmparison

### DIFF
--- a/gnssanalysis/gn_datetime.py
+++ b/gnssanalysis/gn_datetime.py
@@ -338,7 +338,10 @@ def snx_time_to_pydatetime(snx_time: str) -> _datetime:
     """
     year_str, day_str, second_str = snx_time.split(":")
     year_int_2digit = int(year_str)
-    year = year_int_2digit + (2000 if year_int_2digit <= 50 else 1900)
+    if len(year_str) == 4:
+        year = int(year_str)
+    else:
+        year = year_int_2digit + (2000 if year_int_2digit <= 50 else 1900)
     return _datetime(year=year, month=1, day=1) + _timedelta(days=(int(day_str) - 1), seconds=int(second_str))
 
 

--- a/gnssanalysis/gn_io/trop.py
+++ b/gnssanalysis/gn_io/trop.py
@@ -9,32 +9,25 @@ from .. import gn_datetime as _gn_datetime
 from .. import gn_io as _gn_io
 
 
-def _read_tro_solution(path: str, recenter: bool = True, trop_mode="Ginan") -> _pd.DataFrame:
-    """For backwards compatibility"""
-    return read_tro_solution(path, recenter=recenter, trop_mode=trop_mode)
-
-
-def read_tro_solution(path: str, recenter: bool = True, trop_mode="Ginan") -> _pd.DataFrame:
+def read_tro_solution(path: str, trop_mode="Ginan") -> _pd.DataFrame:
     """
     Parses tro snx file into a dataframe.
 
     :param path: path to the `.tro` file
-    :param recenter: recenter overrides day seconds value to midday
     :param trop_mode: format of the tropo solution, can be 'Ginan' or 'Bernese'
 
     :raises ValueError: if `trop_mode` is unsupported
     :returns: `pandas.DataFrame` containing the tropospheric solution section data
     """
     snx_bytes = _gn_io.common.path2bytes(path)
-    return read_tro_solution_bytes(snx_bytes, recenter=recenter, trop_mode=trop_mode)
+    return read_tro_solution_bytes(snx_bytes, trop_mode=trop_mode)
 
 
-def read_tro_solution_bytes(snx_bytes: bytes, recenter: bool = True, trop_mode="Ginan") -> _pd.DataFrame:
+def read_tro_solution_bytes(snx_bytes: bytes, trop_mode="Ginan") -> _pd.DataFrame:
     """
     Parses tro snx file into a dataframe.
 
     :param snx_bytes: contents of the `.tro` file
-    :param recenter: recenter overrides day seconds value to midday
     :param trop_mode: format of the tropo solution, can be 'Ginan' or 'Bernese'
 
     :raises ValueError: if `trop_mode` is unsupported
@@ -93,7 +86,7 @@ def read_tro_solution_bytes(snx_bytes: bytes, recenter: bool = True, trop_mode="
             _tqdm.write(f"{path} data corrupted. Skipping", end=" | ")
             return None
 
-    solution_df.REF_EPOCH = _gn_datetime.yydoysec2datetime(solution_df.REF_EPOCH, recenter=recenter, as_j2000=True)
+    solution_df.REF_EPOCH = solution_df.REF_EPOCH.apply(_gn_datetime.snx_time_to_pydatetime)
     solution_df.set_index(["CODE", "REF_EPOCH"], inplace=True)
     solution_df.columns = _pd.MultiIndex.from_product([product_headers, ["VAL", "STD"]])
     return solution_df

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,5 +1,6 @@
 import unittest
 from gnssanalysis import gn_datetime
+from datetime import datetime as _datetime
 import numpy as np
 
 
@@ -26,3 +27,22 @@ class TestGPSDate(unittest.TestCase):
         np.testing.assert_array_equal(yds_datetime, np.asarray(["2000-01-01T00:00:00"], dtype="datetime64[s]"))
         yds_yds = gn_datetime.datetime2yydoysec(yds_datetime)
         np.testing.assert_array_equal(yds_yds, yds)
+
+
+class TestSNXTimeConversion(unittest.TestCase):
+
+    def test_conversion(self):
+        # Test cases in the format (snx_time, expected_datetime)
+        test_cases = [
+            ('24:001:00000', _datetime(2024, 1, 1, 0, 0, 0)),
+            ('99:365:86399', _datetime(1999, 12, 31, 23, 59, 59)),
+            ('00:001:00000', _datetime(2000, 1, 1, 0, 0, 0)),
+            ('2024:185:11922', _datetime(2024, 7, 3, 3, 18, 42)),
+            ('1970:001:00000', _datetime(1970, 1, 1, 0, 0, 0)),
+            ('75:365:86399', _datetime(1975, 12, 31, 23, 59, 59)),
+        ]
+
+        for snx_time, expected in test_cases:
+            with self.subTest(snx_time=snx_time):
+                self.assertEqual(gn_datetime.snx_time_to_pydatetime(snx_time), expected)
+


### PR DESCRIPTION
Ginan outputs to total delay in ztd in every 20 seconds whereas Bernese does it in every one hour.  So here, I am averaging Ginan data over an hour to match it with Bernese ultra-rapid products. Converting to python datetime makes it easier for pandas dataframe.