### PR TITLE
NPI-3446 Fix SP3 parse and write of data section flags, plus address CLK and POS nodata causing misalignment

### DIFF
--- a/gnssanalysis/gn_io/blq.py
+++ b/gnssanalysis/gn_io/blq.py
@@ -9,7 +9,7 @@ from .common import path2bytes
 
 
 def llh_from_blq(path_or_bytes):
-    _RE_LLH = _re.compile(b"lon\/lat\:\s+([\d\.]+)+\s+([\d\.\-]+)\s+([\d\.\-]+)")
+    _RE_LLH = _re.compile(rb"lon\/lat\:\s+([\d\.]+)+\s+([\d\.\-]+)\s+([\d\.\-]+)")
     llh = _np.asarray(_RE_LLH.findall(path2bytes(path_or_bytes)))
     llh[llh == b""] = 0  # height may be missing, e.g. interpolate_loading's output
     return llh.astype(float)

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -691,7 +691,7 @@ def gen_sp3_content(
         "STD_Z": pos_std_formatter,
         "STD_CLK": clk_std_formatter,  # ditto above
     }
-    for epoch, epoch_vals in out_df.reset_index("PRN").groupby(axis=0, level="J2000"):
+    for epoch, epoch_vals in out_df.reset_index("PRN").groupby(level="J2000"):
         # Format and write out the epoch in the SP3 format
         epoch_datetime = _gn_datetime.j2000_to_pydatetime(epoch)
         frac_seconds = epoch_datetime.second + (epoch_datetime.microsecond * 1e-6)

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -35,7 +35,7 @@ _RE_SP3_HEADER_SV = _re.compile(
 
 # Regex for orbit accuracy codes (E.g. ' 15' - space padded, blocks are three chars wide).
 # Note: header is padded with '  0' entries after the actual data, so empty fields are matched and then trimmed.
-_RE_SP3_HEADER_ACC = _re.compile(rb"^\+{2}[ ]+((?:[\-\d\s]{2}\d){17})$", _re.MULTILINE)
+_RE_SP3_HEADER_ACC = _re.compile(rb"^\+{2}[ ]+((?:[\-\d\s]{2}\d){17})\W", _re.MULTILINE)
 # This matches orbit accuracy codes which are three chars long, left padded with spaces, and always contain at
 # least one digit. They can be negative, though such values are unrealistic. Empty 'entries' are '0', so we have to
 # work out where to trim the data based on the number of SVs in the header.
@@ -43,11 +43,12 @@ _RE_SP3_HEADER_ACC = _re.compile(rb"^\+{2}[ ]+((?:[\-\d\s]{2}\d){17})$", _re.MUL
 # - Match the accuracy code line start of '++' then arbitary spaces, then
 # - 17 columns of:
 #   [space or digit or - ] (times two), then [digit]
-# - Then end of line.
+# - Then non-word char, to match end of line / space.
 
-# Most data matches whether or not we specify the end of line, as we are quite explicit about the format of
-# data we expect. However, using \W instead can be risky, as it fails to match the last line if there is no
-# newline following it. Note though that in SV parsing $ doesn't traverse multiline, the \W works...
+# NOTE: looking for the *end of the line* (i.e. with '$') immediately following the data, would fail to handle files
+# which pad the remainder with spaces.
+# Using \W fails to match the last line if there isn't a newline following, but given the next line should be the %c
+# line, this should never be an issue.
 
 # File descriptor and clock
 _RE_SP3_HEAD_FDESCR = _re.compile(rb"\%c[ ]+(\w{1})[ ]+cc[ ](\w{3})")

--- a/gnssanalysis/gn_io/trop.py
+++ b/gnssanalysis/gn_io/trop.py
@@ -73,7 +73,7 @@ def read_tro_solution_bytes(snx_bytes: bytes, trop_mode="Ginan") -> _pd.DataFram
     try:
         solution_df = _pd.read_csv(
             _BytesIO(tro_estimate),
-            sep='\s+',
+            sep=r"\s+",
             comment=b"*",
             index_col=False,
             header=None,

--- a/gnssanalysis/gn_io/trop.py
+++ b/gnssanalysis/gn_io/trop.py
@@ -23,7 +23,7 @@ def read_tro_solution(path: str, trop_mode="Ginan") -> _pd.DataFrame:
     return read_tro_solution_bytes(snx_bytes, trop_mode=trop_mode)
 
 
-def read_tro_solution_bytes(snx_bytes: bytes, trop_mode="Ginan") -> _pd.DataFrame:
+def read_tro_solution_bytes(snx_bytes: bytes, trop_mode: str = "Ginan") -> _pd.DataFrame:
     """
     Parses tro snx file into a dataframe.
 
@@ -35,8 +35,8 @@ def read_tro_solution_bytes(snx_bytes: bytes, trop_mode="Ginan") -> _pd.DataFram
     """
     tro_estimate = _gn_io.sinex._snx_extract_blk(snx_bytes=snx_bytes, blk_name="TROP/SOLUTION", remove_header=True)
     if tro_estimate is None:
-        _tqdm.write(f"bounds not found in {path}. Skipping.", end=" | ")
-        return None
+        _tqdm.write(f"bounds not found in input bytes beginning '{snx_bytes[:50]}'. Skipping.", end=" | ")
+        return None  # TODO this probably should be an exception
     tro_estimate = tro_estimate[0]  # only single block is in tro so bytes only
 
     if trop_mode == "Ginan":
@@ -83,8 +83,8 @@ def read_tro_solution_bytes(snx_bytes: bytes, trop_mode="Ginan") -> _pd.DataFram
 
     except ValueError as _e:
         if _e.args[0][:33] == "could not convert string to float":
-            _tqdm.write(f"{path} data corrupted. Skipping", end=" | ")
-            return None
+            _tqdm.write(f"Input bytes beginning '{tro_estimate[:50]}': data corrupted. Skipping", end=" | ")
+            return None  # TODO this probably should be an exception
 
     solution_df.REF_EPOCH = solution_df.REF_EPOCH.apply(_gn_datetime.snx_time_to_pydatetime)
     solution_df.set_index(["CODE", "REF_EPOCH"], inplace=True)


### PR DESCRIPTION
- fixed incorrect width of unused columns between data flag values (2 instead of 1). This allows the second prediction flag to be read in.
- Consolidated definitions of columns for maintainability.
- Updated column/index definitions to clearly define a FLAGS index, and specify names of individual flag columns.
- Fixed SP3 output generator to access and output FLAGS data.
- Addressed misalignment bug caused by the combination of CLK nodata value width, and Pandas adding a space between columns. Also applied this fix to POS nodata value, as it appears the same issue would apply there.
- Added handling for missing flag values (conformance to empty strings to avoid outputting nans)
- Added placeholder TODOs for throwing exceptions if record types are encountered that we currently do not implement support for (EP, EV).