### PR TITLE
NPI-3485 Remove deprecated numpy type

### DIFF
--- a/gnssanalysis/gn_io/clk.py
+++ b/gnssanalysis/gn_io/clk.py
@@ -46,9 +46,9 @@ def read_clk(clk_path):
             "D": _np.uint16,
             "h": _np.int32,
             "m": _np.int32,
-            "s": _np.float_,
-            "EST": _np.float_,
-            "STD": _np.float_,
+            "s": _np.float64,
+            "EST": _np.float64,
+            "STD": _np.float64,
         },
         na_values=["NAN", "-NAN"],
     )

--- a/gnssanalysis/gn_io/trace.py
+++ b/gnssanalysis/gn_io/trace.py
@@ -1,4 +1,5 @@
 """TRACE file parser. Note the separate functions for values and residuals"""
+
 import logging as _logging
 import os as _os
 import re as _re
@@ -45,10 +46,10 @@ def _read_trace_states(path_or_bytes, throw_if_nans=False):
 
     if states is None:
         return None
-    
+
     if throw_if_nans:
         _gn_aux.throw_if_nans(states)
-    
+
     df = _pd.read_csv(
         _BytesIO(states),
         delimiter="\t",
@@ -88,7 +89,7 @@ def _read_trace_residuals(path_or_bytes, it_max_only=True, throw_if_nans=False):
 
     if residuals is None:
         return None
-    
+
     if throw_if_nans:
         _gn_aux.throw_if_nans(residuals)
 
@@ -171,8 +172,8 @@ def _find_trace(output_path: str) -> tuple:
 #         {
 #             1: _np.int16, 2:_np.int32, 4: '<U3',
 #             6: '<U1', 8: '<U4',
-#             9: _np.float_, 10: '<U4', 11: _np.float_,
-#             12: '<U4', 13: _np.float_
+#             9: _np.float64, 10: '<U4', 11: _np.float64,
+#             12: '<U4', 13: _np.float64
 #         })
 
 #     df_LC.columns = ['W','S','PRN','LP',8,9,10,11,12,13]


### PR DESCRIPTION
Quick PR to replace the old `np.float_` with `np.float64` in the `clk.py` and `trace.py` IO files.

Some other `black` formatting changes are coming along for the ride as well