### PR TITLE
Restoring backward compatibilities

### DIFF
--- a/.github/workflows/python-cicd-units.yml
+++ b/.github/workflows/python-cicd-units.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-cicd-units.yml
+++ b/.github/workflows/python-cicd-units.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-cicd-units.yml
+++ b/.github/workflows/python-cicd-units.yml
@@ -6,12 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/gnssanalysis/__init__.py
+++ b/gnssanalysis/__init__.py
@@ -14,4 +14,5 @@ from . import (
 )
 
 from . import _version
-__version__ = _version.get_versions()['version']
+
+__version__ = _version.get_versions()["version"]

--- a/gnssanalysis/_version.py
+++ b/gnssanalysis/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -68,12 +67,14 @@ HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
+
     def decorate(f: Callable) -> Callable:
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
@@ -100,10 +101,14 @@ def run_command(
         try:
             dispcmd = str([command] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            process = subprocess.Popen([command] + args, cwd=cwd, env=env,
-                                       stdout=subprocess.PIPE,
-                                       stderr=(subprocess.PIPE if hide_stderr
-                                               else None), **popen_kwargs)
+            process = subprocess.Popen(
+                [command] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+                **popen_kwargs,
+            )
             break
         except OSError as e:
             if e.errno == errno.ENOENT:
@@ -141,15 +146,18 @@ def versions_from_parentdir(
     for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         rootdirs.append(root)
         root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print("Tried directories %s but none started with prefix %s" % (str(rootdirs), parentdir_prefix))
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -212,7 +220,7 @@ def git_versions_from_keywords(
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -221,7 +229,7 @@ def git_versions_from_keywords(
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = {r for r in refs if re.search(r'\d', r)}
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -229,33 +237,35 @@ def git_versions_from_keywords(
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             # Filter out refs that exactly match prefix or that don't start
             # with a number once the prefix is stripped (mostly a concern
             # when prefix is '')
-            if not re.match(r'\d', r):
+            if not re.match(r"\d", r):
                 continue
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
-def git_pieces_from_vcs(
-    tag_prefix: str,
-    root: str,
-    verbose: bool,
-    runner: Callable = run_command
-) -> Dict[str, Any]:
+def git_pieces_from_vcs(tag_prefix: str, root: str, verbose: bool, runner: Callable = run_command) -> Dict[str, Any]:
     """Get version from 'git describe' in the root of the source tree.
 
     This only gets called if the git-archive 'subst' keywords were *not*
@@ -273,8 +283,7 @@ def git_pieces_from_vcs(
     env.pop("GIT_DIR", None)
     runner = functools.partial(runner, env=env)
 
-    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                   hide_stderr=not verbose)
+    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=not verbose)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -282,10 +291,9 @@ def git_pieces_from_vcs(
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = runner(GITS, [
-        "describe", "--tags", "--dirty", "--always", "--long",
-        "--match", f"{tag_prefix}[[:digit:]]*"
-    ], cwd=root)
+    describe_out, rc = runner(
+        GITS, ["describe", "--tags", "--dirty", "--always", "--long", "--match", f"{tag_prefix}[[:digit:]]*"], cwd=root
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -300,8 +308,7 @@ def git_pieces_from_vcs(
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
 
-    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"],
-                             cwd=root)
+    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
     # --abbrev-ref was added in git-1.6.3
     if rc != 0 or branch_name is None:
         raise NotThisMethod("'git rev-parse --abbrev-ref' returned error")
@@ -341,17 +348,16 @@ def git_pieces_from_vcs(
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparsable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -360,10 +366,9 @@ def git_pieces_from_vcs(
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (full_tag, tag_prefix)
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -412,8 +417,7 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -442,8 +446,7 @@ def render_pep440_branch(pieces: Dict[str, Any]) -> str:
         rendered = "0"
         if pieces["branch"] != "master":
             rendered += ".dev0"
-        rendered += "+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered += "+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -604,11 +607,13 @@ def render_git_describe_long(pieces: Dict[str, Any]) -> str:
 def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -632,9 +637,13 @@ def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions() -> Dict[str, Any]:
@@ -648,8 +657,7 @@ def get_versions() -> Dict[str, Any]:
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -658,13 +666,16 @@ def get_versions() -> Dict[str, Any]:
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for _ in cfg.versionfile_source.split('/'):
+        for _ in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -678,6 +689,10 @@ def get_versions() -> Dict[str, Any]:
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/gnssanalysis/filenames.py
+++ b/gnssanalysis/filenames.py
@@ -407,21 +407,20 @@ def convert_nominal_span(nominal_span: str) -> datetime.timedelta:
     """
     span = int(nominal_span[0:2])
     unit = nominal_span[2].upper()
-    if unit == "S":
-        return datetime.timedelta(seconds=span)
-    elif unit == "M":
-        return datetime.timedelta(minutes=span)
-    elif unit == "H":
-        return datetime.timedelta(hours=span)
-    elif unit == "D":
-        return datetime.timedelta(days=span)
-    elif unit == "W":
-        return datetime.timedelta(weeks=span)
-    elif unit == "L":
-        return datetime.timedelta(days=span * 28)
-    elif unit == "Y":
-        return datetime.timedelta(days=span * 365)
-    else:
+    unit_to_timedelta_args = {
+        "S": {"seconds": 1},
+        "M": {"minutes": 1},
+        "H": {"hours": 1},
+        "D": {"days": 1},
+        "W": {"weeks": 1},
+        "L": {"days": 28},
+        "Y": {"days": 365},
+    }
+    try:
+        timedelta_args = unit_to_timedelta_args[unit]
+        return datetime.timedelta(**{k: v * span for k, v in timedelta_args.items()})
+    except KeyError:
+        logging.warning("Time unit '%s' not understood", unit)
         return datetime.timedelta()
 
 

--- a/gnssanalysis/gn_const.py
+++ b/gnssanalysis/gn_const.py
@@ -1,4 +1,5 @@
 """Constants to be declared here"""
+
 import numpy as _np
 import pandas as _pd
 

--- a/gnssanalysis/gn_datetime.py
+++ b/gnssanalysis/gn_datetime.py
@@ -3,9 +3,7 @@
 from datetime import datetime as _datetime
 from datetime import timedelta as _timedelta
 from io import StringIO as _StringIO
-from typing import Optional as _Optional
-from typing import Union as _Union
-from typing import overload as _overload
+from typing import Optional, overload, Union
 
 import numpy as _np
 import pandas as _pd
@@ -133,7 +131,7 @@ def gpswkD2dt(gpswkD):
 
 
 def yydoysec2datetime(
-    arr: _Union[_np.ndarray, _pd.Series, list], recenter: bool = False, as_j2000: bool = True, delimiter: str = ":"
+    arr: Union[_np.ndarray, _pd.Series, list], recenter: bool = False, as_j2000: bool = True, delimiter: str = ":"
 ) -> _np.ndarray:
     """Converts snx YY:DOY:SSSSS [snx] or YYYY:DOY:SSSSS [bsx/bia] object Series/ndarray to datetime64.
     recenter overrides day seconds value to midday
@@ -152,7 +150,7 @@ def yydoysec2datetime(
     return datetime2j2000(datetime64) if as_j2000 else datetime64
 
 
-def datetime2yydoysec(datetime: _Union[_np.ndarray, _pd.Series]) -> _np.ndarray:
+def datetime2yydoysec(datetime: Union[_np.ndarray, _pd.Series]) -> _np.ndarray:
     """datetime64[s] -> yydoysecond
     The '2000-01-01T00:00:00' (-43200 J2000 for 00:000:00000) datetime becomes 00:000:00000 as it should,
     No masking and overriding with year 2100 is needed"""
@@ -181,7 +179,7 @@ def gpsweeksec2datetime(gps_week: _np.ndarray, tow: _np.ndarray, as_j2000: bool 
     return datetime
 
 
-def datetime2gpsweeksec(array: _np.ndarray, as_decimal=False) -> _Union[tuple, _np.ndarray]:
+def datetime2gpsweeksec(array: _np.ndarray, as_decimal=False) -> Union[tuple, _np.ndarray]:
     if array.dtype == int:
         ORIGIN = _gn_const.J2000_ORIGIN.astype("int64") - _gn_const.GPS_ORIGIN.astype("int64")
         gps_time = array + ORIGIN  # need int conversion for the case of datetime64
@@ -345,15 +343,15 @@ def snx_time_to_pydatetime(snx_time: str) -> _datetime:
     return _datetime(year=year, month=1, day=1) + _timedelta(days=(int(day_str) - 1), seconds=int(second_str))
 
 
-@_overload
+@overload
 def round_timedelta(
-    delta: _timedelta, roundto: _timedelta, *, tol: float = ..., abs_tol: _Optional[_timedelta]
+    delta: _timedelta, roundto: _timedelta, *, tol: float = ..., abs_tol: Optional[_timedelta]
 ) -> _timedelta: ...
 
 
-@_overload
+@overload
 def round_timedelta(
-    delta: _np.timedelta64, roundto: _np.timedelta64, *, tol: float = ..., abs_tol: _Optional[_np.timedelta64]
+    delta: _np.timedelta64, roundto: _np.timedelta64, *, tol: float = ..., abs_tol: Optional[_np.timedelta64]
 ) -> _np.timedelta64: ...
 
 

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -890,13 +890,11 @@ def download_atx(download_dir: _Path, reference_frame: str = "IGS20", if_file_pr
     :raises ValueError: If an invalid option is given for reference_frame variable
     :return _Path: The pathlib.Path of the downloaded file
     """
-    match reference_frame:
-        case "IGS20":
-            atx_filename = "igs20.atx"
-        case "IGb14":
-            atx_filename = "igs14.atx"
-        case _:
-            raise ValueError("Invalid value passed for reference_frame var. Must be either 'IGS20' or 'IGb14'")
+    reference_frame_to_filename = {"IGS20": "igs20.atx", "IGb14": "igs14.atx"}
+    try:
+        atx_filename = reference_frame_to_filename[reference_frame]
+    except KeyError:
+        raise ValueError("Invalid value passed for reference_frame var. Must be either 'IGS20' or 'IGb14'")
 
     ensure_folders([download_dir])
 

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -25,7 +25,7 @@ import hatanaka as _hatanaka
 import ftplib as _ftplib
 from ftplib import FTP_TLS as _FTP_TLS
 from pathlib import Path as _Path
-from typing import Optional as _Optional, Tuple as _Tuple, List as _List
+from typing import Any, Generator, List, Optional, Tuple, Union
 from urllib import request as _request
 from urllib.error import HTTPError as _HTTPError
 
@@ -121,7 +121,7 @@ def upload_with_chunksize_and_meta(
     # return transfer_callback.thread_info
 
 
-def request_metadata(url: str, max_retries: int = 5, metadata_header: str = "x-amz-meta-md5checksum") -> _Optional[str]:
+def request_metadata(url: str, max_retries: int = 5, metadata_header: str = "x-amz-meta-md5checksum") -> Optional[str]:
     """requests md5checksum metadata over https (AWS S3 bucket)
     Returns None if file not found (404) or if md5checksum metadata key does not exist"""
     logging.info(f'requesting checksum for "{url}"')
@@ -147,7 +147,7 @@ def request_metadata(url: str, max_retries: int = 5, metadata_header: str = "x-a
     return None
 
 
-def download_url(url: str, destfile: str | _os.PathLike, max_retries: int = 5) -> _Optional[_Path]:
+def download_url(url: str, destfile: str | _os.PathLike, max_retries: int = 5) -> Optional[_Path]:
     logging.info(f'requesting "{url}"')
     for retry in range(1, max_retries + 1):
         try:
@@ -370,7 +370,7 @@ def generate_product_filename(
     version: str = "0",
     project: str = "OPS",
     content_type: str = None,
-) -> _Tuple[str, GPSDate, _datetime.datetime]:
+) -> Tuple[str, GPSDate, _datetime.datetime]:
     """Given a reference datetime and extention of file, generate the IGS filename and GPSDate obj for use in download
 
     :param _datetime.datetime reference_start: Datetime of the start period of interest
@@ -418,7 +418,9 @@ def generate_product_filename(
     return product_filename, gps_date, reference_start
 
 
-def check_whether_to_download(filename: str, download_dir: _Path, if_file_present: str = "prompt_user") -> _Path | None:
+def check_whether_to_download(
+    filename: str, download_dir: _Path, if_file_present: str = "prompt_user"
+) -> Union[_Path, None]:
     """Determine whether to download given file (filename) to the desired location (download_dir) based on whether it is
     already present and what action to take if it is (if_file_present)
 
@@ -687,7 +689,7 @@ def connect_cddis(verbose=False):
 
 
 @_contextmanager
-def ftp_tls(url: str, **kwargs) -> None:
+def ftp_tls(url: str, **kwargs) -> Generator[Any, Any, Any]:
     """Opens a connect to specified ftp server over tls.
 
     :param: url: Remote ftp url
@@ -755,7 +757,7 @@ def download_file_from_cddis(
     return download_filepath
 
 
-def download_multiple_files_from_cddis(files: _List[str], ftp_folder: str, output_folder: _Path) -> None:
+def download_multiple_files_from_cddis(files: List[str], ftp_folder: str, output_folder: _Path) -> None:
     """Downloads multiple files in a single folder from cddis in a thread pool.
 
     :param files: List of str filenames
@@ -773,7 +775,7 @@ def download_product_from_cddis(
     end_epoch: _datetime,
     file_ext: str,
     limit: int = None,
-    long_filename: _Optional[bool] = None,
+    long_filename: Optional[bool] = None,
     analysis_center: str = "IGS",
     solution_type: str = "ULT",
     sampling_rate: str = "15M",
@@ -938,12 +940,12 @@ def download_satellite_metadata_snx(download_dir: _Path, if_file_present: str = 
     return download_filepath
 
 
-def download_yaw_files(download_dir: _Path, if_file_present: str = "prompt_user") -> _List[_Path]:
+def download_yaw_files(download_dir: _Path, if_file_present: str = "prompt_user") -> List[_Path]:
     """Download yaw rate / bias files needed to for Ginan's PEA
 
     :param _Path download_dir: Where to download files (local directory)
     :param str if_file_present: What to do if file already present: "replace", "dont_replace", defaults to "prompt_user"
-    :return _List[_Path]: Return list of download files
+    :return List[_Path]: Return list of download files
     """
     ensure_folders([download_dir])
     download_filepaths = []

--- a/gnssanalysis/gn_download.py
+++ b/gnssanalysis/gn_download.py
@@ -147,7 +147,7 @@ def request_metadata(url: str, max_retries: int = 5, metadata_header: str = "x-a
     return None
 
 
-def download_url(url: str, destfile: str | _os.PathLike, max_retries: int = 5) -> Optional[_Path]:
+def download_url(url: str, destfile: Union[str, _os.PathLike], max_retries: int = 5) -> Optional[_Path]:
     logging.info(f'requesting "{url}"')
     for retry in range(1, max_retries + 1):
         try:
@@ -427,7 +427,7 @@ def check_whether_to_download(
     :param str filename: Filename of the downloaded file
     :param _Path download_dir: Where to download files (local directory)
     :param str if_file_present: What to do if file already present: "replace", "dont_replace", defaults to "prompt_user"
-    :return _Path | None: pathlib.Path to the downloaded file if file should be downloaded, otherwise returns None
+    :return _Path or None: pathlib.Path to the downloaded file if file should be downloaded, otherwise returns None
     """
     # Flag to determine whether to download:
     download = None

--- a/gnssanalysis/gn_frame.py
+++ b/gnssanalysis/gn_frame.py
@@ -1,6 +1,7 @@
 """frame of day generation module"""
+
 import logging
-from typing import Union as _Union
+from typing import Union
 
 import numpy as _np
 import pandas as _pd
@@ -27,10 +28,10 @@ def _get_core_list(core_list_path):
 
 def get_frame_of_day(
     date_or_j2000,
-    itrf_path_or_df: _Union[_pd.DataFrame, str],
-    discon_path_or_df: _Union[_pd.DataFrame, str],
-    psd_path_or_df: _Union[None, _pd.DataFrame, str] = None,
-    list_path_or_df: _Union[None, _pd.DataFrame, str, _np.ndarray] = None,
+    itrf_path_or_df: Union[_pd.DataFrame, str],
+    discon_path_or_df: Union[_pd.DataFrame, str],
+    psd_path_or_df: Union[None, _pd.DataFrame, str] = None,
+    list_path_or_df: Union[None, _pd.DataFrame, str, _np.ndarray] = None,
 ):
     """Main function to propagate frame into datetime of interest"""
 

--- a/gnssanalysis/gn_io/discon.py
+++ b/gnssanalysis/gn_io/discon.py
@@ -1,4 +1,5 @@
 """Parser of frame discontinuity file"""
+
 from io import BytesIO as _BytesIO
 
 import pandas as _pd

--- a/gnssanalysis/gn_io/erp.py
+++ b/gnssanalysis/gn_io/erp.py
@@ -2,6 +2,7 @@ import datetime
 import math
 import os
 import pathlib
+
 # The collections.abc (rather than typing) versions don't support subscripting until 3.9
 # from collections.abc import Callable, Iterable
 from typing import Callable, Iterable
@@ -201,7 +202,11 @@ def get_erp_unit_string(normalised_header: str, original_header: str) -> str:
         return "E-6as/d"
     elif normalised_header in ["UT1-UTC", "UT1R-UTC", "UT1-TAI", "UT1R-TAI", "UTsig", "UTRsig"]:
         return "E-7s"
-    elif normalised_header in ["LOD", "LODR", "LODsig", ]:
+    elif normalised_header in [
+        "LOD",
+        "LODR",
+        "LODsig",
+    ]:
         return "E-7s/d"
     elif normalised_header in ["Deps", "Depssig", "Dpsi", "Dpsisig"]:
         return "E-6"
@@ -352,7 +357,7 @@ def write_erp_to_stream(erp_df: _pd.DataFrame, stream: TextIO, mjd_precision: in
     stream.write(" ".join(s.rjust(w) for (s, w) in zip(unit_strings, column_widths)))
     stream.write("\n")
     # Values
-    for (_, row) in value_strings_df.iterrows():
+    for _, row in value_strings_df.iterrows():
         stream.write(" ".join(s.rjust(w) for (s, w) in zip(row, column_widths)))
         stream.write("\n")
 

--- a/gnssanalysis/gn_io/ionex.py
+++ b/gnssanalysis/gn_io/ionex.py
@@ -31,7 +31,7 @@ def read_ionex(path_or_bytes):
     data = _gn_io.common.path2bytes(path_or_bytes)
     end_of_head = data.find(b"END OF HEADER")
     if end_of_head == -1:
-        raise ValueError ('IONEX header missing')
+        raise ValueError("IONEX header missing")
     end_of_head += 13
 
     head = data[:end_of_head]
@@ -39,7 +39,7 @@ def read_ionex(path_or_bytes):
 
     maps_heads = find_all(data, b"START", window=[9, 60])  # type + epoch info
     if not maps_heads:
-        raise ValueError ('IONEX maps not found')
+        raise ValueError("IONEX maps not found")
     maps_heads_arr = _np.asarray(b"".join(maps_heads).split()).reshape(len(maps_heads), -1)
     # return maps_heads
     datetime = _gn_datetime.strdatetime2datetime(maps_heads_arr[:, 2:], as_j2000=True)

--- a/gnssanalysis/gn_io/psd.py
+++ b/gnssanalysis/gn_io/psd.py
@@ -1,4 +1,5 @@
 """ITRF2014+ postseismic deformation file"""
+
 from .. import gn_io as _gn_io
 
 

--- a/gnssanalysis/gn_io/rinex.py
+++ b/gnssanalysis/gn_io/rinex.py
@@ -24,7 +24,11 @@ def _read_rnx(rnx_path):
         data_bytes = header_bytes
 
     signal_header_marker = b"SYS / # / OBS TYPES"
-    signal_lines = (line.removesuffix(signal_header_marker).decode() for line in header_bytes.splitlines() if line.endswith(signal_header_marker))
+    signal_lines = (
+        line.removesuffix(signal_header_marker).decode()
+        for line in header_bytes.splitlines()
+        if line.endswith(signal_header_marker)
+    )
     constellation_signals = {}
     constellation_code = ""
     for line in signal_lines:
@@ -42,8 +46,10 @@ def _read_rnx(rnx_path):
         identifier_count = len(signal_identifiers)
         maximum_columns = max(maximum_columns, identifier_count)
         if signal_count != identifier_count:
-            _logging.warning(f"Disagreement in signal count for constellation {code}, reported {signal_count} signals"
-                             f", found {identifier_count}: {signal_identifiers}")
+            _logging.warning(
+                f"Disagreement in signal count for constellation {code}, reported {signal_count} signals"
+                f", found {identifier_count}: {signal_identifiers}"
+            )
             constellation_signals[code][0] = identifier_count
 
     data_blocks = _np.asarray(_RE_RNX.findall(string=data_bytes))
@@ -51,7 +57,9 @@ def _read_rnx(rnx_path):
     data_record_blocks = data_blocks[:, 1]
     record_counts = _np.char.count(data_record_blocks, b"\n")
 
-    dates_as_datetimes = _pd.to_datetime(_pd.Series(dates).str.slice(1, 20).values.astype(str), format=r"%Y %m %d %H %M %S")
+    dates_as_datetimes = _pd.to_datetime(
+        _pd.Series(dates).str.slice(1, 20).values.astype(str), format=r"%Y %m %d %H %M %S"
+    )
     datetime_index = _np.repeat(_gn_datetime.datetime2j2000(dates_as_datetimes), repeats=record_counts)
 
     data_records = _pd.Series(_np.concatenate(_np.char.splitlines(data_record_blocks)))

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -29,9 +29,7 @@ _RE_SP3_HEAD = _re.compile(
 _RE_SP3_COMMENT_STRIP = _re.compile(rb"^(\/\*.*$\n)", _re.MULTILINE)
 # Regex to extract Satellite Vehicle (SV) names (E.g. G02). In SP3-d (2016) up to 999 satellites can be included).
 # Regex options/flags: multiline, findall. Updated to extract expected SV count too.
-_RE_SP3_HEADER_SV = _re.compile(
-    rb"^\+[ ]+([\d]+|)[ ]+((?:[A-Z]\d{2})+)\W", _re.MULTILINE
-)
+_RE_SP3_HEADER_SV = _re.compile(rb"^\+[ ]+([\d]+|)[ ]+((?:[A-Z]\d{2})+)\W", _re.MULTILINE)
 
 # Regex for orbit accuracy codes (E.g. ' 15' - space padded, blocks are three chars wide).
 # Note: header is padded with '  0' entries after the actual data, so empty fields are matched and then trimmed.
@@ -240,9 +238,7 @@ def _process_sp3_block(
     return temp_sp3
 
 
-def read_sp3(
-    sp3_path: str, pOnly: bool = True, nodata_to_nan: bool = True
-) -> _pd.DataFrame:
+def read_sp3(sp3_path: str, pOnly: bool = True, nodata_to_nan: bool = True) -> _pd.DataFrame:
     """Reads an SP3 file and returns the data as a pandas DataFrame.
 
 
@@ -360,9 +356,7 @@ def _split_sp3_content(content: bytes) -> Tuple[List[str], _np.ndarray]:
     return date_lines, data_blocks
 
 
-def parse_sp3_header(
-    header: bytes, warn_on_negative_sv_acc_values: bool = True
-) -> _pd.Series:
+def parse_sp3_header(header: bytes, warn_on_negative_sv_acc_values: bool = True) -> _pd.Series:
     """
     Parse the header of an SP3 file and extract relevant information.
 
@@ -371,10 +365,9 @@ def parse_sp3_header(
     """
     try:
         sp3_heading = _pd.Series(
-            data=_np.asarray(
-                _RE_SP3_HEAD.search(header).groups()
-                + _RE_SP3_HEAD_FDESCR.search(header).groups()
-            ).astype(str),
+            data=_np.asarray(_RE_SP3_HEAD.search(header).groups() + _RE_SP3_HEAD_FDESCR.search(header).groups()).astype(
+                str
+            ),
             index=[
                 "VERSION",
                 "PV_FLAG",
@@ -389,9 +382,7 @@ def parse_sp3_header(
             ],
         )
     except AttributeError as e:  # Make the exception slightly clearer.
-        raise AttributeError(
-            "Failed to parse SP3 header. Regex likely returned no match.", e
-        )
+        raise AttributeError("Failed to parse SP3 header. Regex likely returned no match.", e)
 
     # Find all Satellite Vehicle (SV) entries
     # Updated to also extract the count of expected SVs from the header, and compare that to the number of SVs we get.
@@ -566,15 +557,7 @@ def gen_sp3_header(sp3_df: _pd.DataFrame) -> str:
 
     comment = ["/*\n"] * 4
 
-    return "".join(
-        line1
-        + line2
-        + sats_header.tolist()
-        + sv_orb_head.tolist()
-        + head_c
-        + head_fi
-        + comment
-    )
+    return "".join(line1 + line2 + sats_header.tolist() + sv_orb_head.tolist() + head_c + head_fi + comment)
 
 
 def gen_sp3_content(

--- a/gnssanalysis/gn_io/trop.py
+++ b/gnssanalysis/gn_io/trop.py
@@ -1,4 +1,5 @@
 """Trop sinex files reader/parser"""
+
 from io import BytesIO as _BytesIO
 
 import numpy as _np

--- a/gnssanalysis/gn_plot.py
+++ b/gnssanalysis/gn_plot.py
@@ -76,7 +76,7 @@ def diff2plot(diff, kind=None, title="Unnamed plot"):
         if mask0.any():
             cols = diff.columns[mask0]
             x1 = _gn_datetime.j20002datetime(diff.index.values).astype(str)
-            plx.datetime._datetime_form = "%Y-%m-%dT%H:%M:%S" # change parsed format to numpy-like
+            plx.datetime._datetime_form = "%Y-%m-%dT%H:%M:%S"  # change parsed format to numpy-like
             for i in range(cols.shape[0]):
                 plx.scatter_date(x1, diff[cols[i]].to_list(), color=i, marker="hd", label=diff.columns[i])
                 plx.plotsize(100, 30 + 3)

--- a/gnssanalysis/gn_utils.py
+++ b/gnssanalysis/gn_utils.py
@@ -5,7 +5,7 @@ import pathlib as _pathlib
 
 import click as _click
 
-from typing import List as _List
+from typing import List, Union
 
 
 def diffutil_verify_input(input):
@@ -52,7 +52,7 @@ def get_filetype(path):
     return suffix
 
 
-def configure_logging(verbose: bool, output_logger: bool = False) -> _logging.Logger | None:
+def configure_logging(verbose: bool, output_logger: bool = False) -> Union[_logging.Logger, None]:
     """Configure the logger object with the level of verbosity requested and output if desired
 
     :param bool verbose: Verbosity of logger object to use for encoding logging strings, True: DEBUG, False: INFO
@@ -71,10 +71,10 @@ def configure_logging(verbose: bool, output_logger: bool = False) -> _logging.Lo
         return None
 
 
-def ensure_folders(paths: _List[_pathlib.Path]):
+def ensure_folders(paths: List[_pathlib.Path]):
     """Ensures the folders in the input list exist in the file system - if not, create them
 
-    :param _List[_pathlib.Path] paths: list of pathlib.Path/s to check
+    :param List[_pathlib.Path] paths: list of pathlib.Path/s to check
     """
     for path in paths:
         if not isinstance(path, _pathlib.Path):


### PR DESCRIPTION
Changes in the code to make the package compatible for python 3.9 again. 
Python 3.9 is the default install on Apple MacOS, it's end of life is in October 2025. 

Main changes are:
- moved from match/case statement to dictionary (1 occurence)
- moved from the typehint `|` operator to `Union` 

a few other fixes/simplification the time I was doing it. 