### PR TITLE
NPI-3653 - Update code to handle new V2 IGS logs

### DIFF
--- a/gnssanalysis/gn_io/igslog.py
+++ b/gnssanalysis/gn_io/igslog.py
@@ -159,7 +159,7 @@ def parse_igs_log(filename_array: _np.ndarray) -> _np.ndarray:
     :param _np.ndarray filename_array: Metadata on input log file. Expects ndarray of the form [CODE DATE PATH]
     :return _np.ndarray: Returns array with data from the IGS log file parsed
     """
-    file_code, __, file_path = filename_array
+    file_code, _, file_path = filename_array
 
     with open(file_path, "rb") as file:
         data = file.read()

--- a/gnssanalysis/gn_io/igslog.py
+++ b/gnssanalysis/gn_io/igslog.py
@@ -294,13 +294,13 @@ def translate_series(series: _pd.Series, translation: dict) -> _pd.Series:
 
 def gather_metadata(
     logs_glob_path: str = "/data/station_logs/station_logs_IGS/*/*.log", rnx_glob_path: str = None, num_threads: int = 1
-) -> _List[_pd.DataFrame, _pd.DataFrame, _pd.DataFrame]:
+) -> _List[_pd.DataFrame]:
     """Parses log files found with glob expressions into pd.DataFrames
 
     :param str logs_glob_path: A glob expression for log files, defaults to "/data/station_logs_IGS/*/*.log"
     :param str rnx_glob_path: A glob expression for rnx files, e.g. /data/pea/exs/data/*.rnx, defaults to None
     :param int num_threads: Number of threads to run, defaults to 1
-    :return _List[_pd.DataFrame, _pd.DataFrame, _pd.DataFrame]: List of DataFrames with [ID, Receiver, Antenna] data
+    :return _List[_pd.DataFrame]: List of DataFrames with [ID, Receiver, Antenna] data
     """
     parsed_filenames = find_recent_logs(logs_glob_path=logs_glob_path, rnx_glob_path=rnx_glob_path).values
 

--- a/gnssanalysis/gn_io/igslog.py
+++ b/gnssanalysis/gn_io/igslog.py
@@ -105,6 +105,14 @@ _REGEX_ANT = _re.compile(
 _REGEX_LOGNAME = r"(?:.*\/)(\w{4})(?:\w+_(\d{8})|_(\d{8})\-?\w?|(\d{8})|_.*|\d+|)"
 
 
+class LogVersionError(Exception):
+    """
+    Log file read does not conform to known IGS version standard
+    """
+
+    pass
+
+
 def find_recent_logs(logs_glob_path: str, rnx_glob_path: str = None) -> _pd.DataFrame:
     """Takes glob expression to create list of logs, parses names into site and date and selects most recent ones
 
@@ -150,7 +158,7 @@ def determine_log_version(data: bytes) -> str:
     if result_v2:
         return "v2.0"
 
-    raise ValueError("Log file does not conform to any known IGS version")
+    raise LogVersionError("Log file does not conform to any known IGS version")
 
 
 def parse_igs_log(filename_array: _np.ndarray) -> _np.ndarray:
@@ -166,7 +174,7 @@ def parse_igs_log(filename_array: _np.ndarray) -> _np.ndarray:
 
     try:
         version = determine_log_version(data)
-    except ValueError as e:
+    except LogVersionError as e:
         logger.warning(f"Error: {e}, skipping parsing the log file")
 
     if version == "v1.0":

--- a/gnssanalysis/gn_io/igslog.py
+++ b/gnssanalysis/gn_io/igslog.py
@@ -138,7 +138,7 @@ def determine_log_version(data: bytes) -> str:
     """Given the byes object that results from reading an IGS log file, determine the version ("v1.0" or "v2.0")
 
     :param bytes data: IGS log file bytes object to determine the version of
-    :return str: Return the version number: "v1.0" or "v2.0" (or "Unknown" if file does not confirm to standard)
+    :return str: Return the version number: "v1.0" or "v2.0" (or "Unknown" if file does not conform to standard)
     """
     # check for version:
 
@@ -150,7 +150,7 @@ def determine_log_version(data: bytes) -> str:
     if result_v2:
         return "v2.0"
 
-    return "Unknown"
+    raise ValueError("Log file does not conform to any known IGS version")
 
 
 def parse_igs_log(filename_array: _np.ndarray) -> _np.ndarray:
@@ -164,7 +164,10 @@ def parse_igs_log(filename_array: _np.ndarray) -> _np.ndarray:
     with open(file_path, "rb") as file:
         data = file.read()
 
-    version = determine_log_version(data)
+    try:
+        version = determine_log_version(data)
+    except ValueError as e:
+        logger.warning(f"Error: {e}, skipping parsing the log file")
 
     if version == "v1.0":
         _REGEX_ID = _REGEX_ID_V1

--- a/tests/test_datasets/sitelog_test_data.py
+++ b/tests/test_datasets/sitelog_test_data.py
@@ -1,0 +1,329 @@
+# Central record of IGS site log test data sets to be shared across unit tests
+
+# first dataset is a truncated version of file abmf_20240710.log
+
+abmf_site_log_v1 = bytes(
+    """
+     ABMF Site Information Form (site log)
+     International GNSS Service
+     See Instructions at:
+       https://files.igs.org/pub/station/general/sitelog_instr.txt
+
+0.   Form
+
+     Prepared by (full name)  : RGP TEAM
+     Date Prepared            : 2024-07-10
+     Report Type              : UPDATE
+     If Update:
+      Previous Site Log       : (ssss_ccyymmdd.log)
+      Modified/Added Sections : (n.n,n.n,...)
+
+
+1.   Site Identification of the GNSS Monument
+
+     Site Name                : Aeroport du Raizet -LES ABYMES - Météo France
+     Four Character ID        : ABMF
+     Monument Inscription     : NONE
+     IERS DOMES Number        : 97103M001
+     CDP Number               : NONE
+     Monument Description     : INOX TRIANGULAR PLATE ON TOP OF METALLIC PILAR
+       Height of the Monument : 2.0 m
+       Monument Foundation    : ROOF
+       Foundation Depth       : 4.0 m
+     Marker Description       : TOP AND CENTRE OF THE TRIANGULAR PLATE
+     Date Installed           : 2008-07-15T00:00Z
+     Geologic Characteristic  : 
+       Bedrock Type           : 
+       Bedrock Condition      : 
+       Fracture Spacing       : 11-50 cm
+       Fault zones nearby     : 
+         Distance/activity    : 
+     Additional Information   : 
+
+
+2.   Site Location Information
+
+     City or Town             : Les Abymes
+     State or Province        : Guadeloupe (971)
+     Country                  : Guadeloupe
+     Tectonic Plate           : CARIBBEAN
+     Approximate Position (ITRF)
+       X coordinate (m)       : 2919786.0
+       Y coordinate (m)       : -5383745.0
+       Z coordinate (m)       : 1774604.0
+       Latitude (N is +)      : +161544.30
+       Longitude (E is +)     : -0613139.11
+       Elevation (m,ellips.)  : -25.0
+     Additional Information   : 
+
+
+3.   GNSS Receiver Information
+
+3.1 Receiver Type            : LEICA GR25
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 1830399
+     Firmware Version         : 4.31
+     Elevation Cutoff Setting : 3 deg
+     Date Installed           : 2019-03-13T17:00Z
+     Date Removed             : 2019-04-15T12:00Z
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.2 Receiver Type            : SEPT POLARX5
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 3013312
+     Firmware Version         : 5.2.0
+     Elevation Cutoff Setting : 0 deg
+     Date Installed           : 2019-04-15T12:00Z
+     Date Removed             : 2019-10-01T16:00Z
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.3 Receiver Type            : SEPT POLARX5
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 3013312
+     Firmware Version         : 5.3.0
+     Elevation Cutoff Setting : 0 deg
+     Date Installed           : 2019-10-01T16:00Z
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.x  Receiver Type            : (A20, from rcvr_ant.tab; see instructions)
+     Satellite System         : (GPS+GLO+GAL+BDS+QZSS+SBAS)
+     Serial Number            : (A20, but note the first A5 is used in SINEX)
+     Firmware Version         : (A11)
+     Elevation Cutoff Setting : (deg)
+     Date Installed           : (CCYY-MM-DDThh:mmZ)
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Temperature Stabiliz.    : (none or tolerance in degrees C)
+     Additional Information   : (multiple lines)
+
+
+4.   GNSS Antenna Information
+
+4.1  Antenna Type             : AERAT2775_43    SPKE
+     Serial Number            : 5546
+     Antenna Reference Point  : TOP
+     Marker->ARP Up Ecc. (m)  : 000.0500
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : SPKE
+     Radome Serial Number     : NONE
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2008-07-15T00:00Z
+     Date Removed             : 2009-10-15T20:00Z
+     Additional Information   : 
+
+4.2  Antenna Type             : TRM55971.00     NONE
+     Serial Number            : 1440911917
+     Antenna Reference Point  : BAM
+     Marker->ARP Up Ecc. (m)  : 000.0000
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : NONE
+     Radome Serial Number     : 
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2009-10-15T20:00Z
+     Date Removed             : 2012-01-24T12:00Z
+     Additional Information   : 
+
+4.3  Antenna Type             : TRM57971.00     NONE
+     Serial Number            : 1441112501
+     Antenna Reference Point  : BAM
+     Marker->ARP Up Ecc. (m)  : 000.0000
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : NONE
+     Radome Serial Number     : 
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2012-01-24T12:00Z
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Additional Information   : 
+
+4.x  Antenna Type             : (A20, from rcvr_ant.tab; see instructions)
+     Serial Number            : (A*, but note the first A5 is used in SINEX)
+     Antenna Reference Point  : (BPA/BCR/XXX from "antenna.gra"; see instr.)
+     Marker->ARP Up Ecc. (m)  : (F8.4)
+     Marker->ARP North Ecc(m) : (F8.4)
+     Marker->ARP East Ecc(m)  : (F8.4)
+     Alignment from True N    : (deg; + is clockwise/east)
+     Antenna Radome Type      : (A4 from rcvr_ant.tab; see instructions)
+     Radome Serial Number     : 
+     Antenna Cable Type       : (vendor & type number)
+     Antenna Cable Length     : (m)
+     Date Installed           : (CCYY-MM-DDThh:mmZ)
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Additional Information   : (multiple lines)
+     """,
+    "utf-8",
+)
+
+abmf_site_log_v2 = bytes(
+    """
+     ABMF00GLP Site Information Form (site log v2.0)
+     International GNSS Service
+     See Instructions at:
+       https://files.igs.org/pub/station/general/sitelog_instr_v2.0.txt
+
+0.   Form
+
+     Prepared by (full name)  : RGP TEAM
+     Date Prepared            : 2024-07-10
+     Report Type              : UPDATE
+     If Update:
+      Previous Site Log       : (ssssmrccc_ccyymmdd.log)
+      Modified/Added Sections : (n.n,n.n,...)
+
+
+1.   Site Identification of the GNSS Monument
+
+     Site Name                : Aeroport du Raizet -LES ABYMES - Météo France
+     Nine Character ID        : ABMF00GLP
+     Monument Inscription     : NONE
+     IERS DOMES Number        : 97103M001
+     CDP Number               : NONE
+     Monument Description     : INOX TRIANGULAR PLATE ON TOP OF METALLIC PILAR
+       Height of the Monument : 2.0 m
+       Monument Foundation    : ROOF
+       Foundation Depth       : 4.0 m
+     Marker Description       : TOP AND CENTRE OF THE TRIANGULAR PLATE
+     Date Installed           : 2008-07-15T00:00Z
+     Geologic Characteristic  : 
+       Bedrock Type           : 
+       Bedrock Condition      : 
+       Fracture Spacing       : 11-50 cm
+       Fault zones nearby     : 
+         Distance/activity    : 
+     Additional Information   : 
+
+
+2.   Site Location Information
+
+     City or Town             : Les Abymes
+     State or Province        : Guadeloupe (971)
+     Country or Region        : GLP
+     Tectonic Plate           : CARIBBEAN
+     Approximate Position (ITRF)
+       X coordinate (m)       : 2919786.0
+       Y coordinate (m)       : -5383745.0
+       Z coordinate (m)       : 1774604.0
+       Latitude (N is +)      : +161544.30
+       Longitude (E is +)     : -0613139.11
+       Elevation (m,ellips.)  : -25.0
+     Additional Information   : 
+
+
+3.   GNSS Receiver Information
+
+3.1 Receiver Type            : LEICA GR25
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 1830399
+     Firmware Version         : 4.31
+     Elevation Cutoff Setting : 3 deg
+     Date Installed           : 2019-03-13T17:00Z
+     Date Removed             : 2019-04-15T12:00Z
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.2 Receiver Type            : SEPT POLARX5
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 3013312
+     Firmware Version         : 5.2.0
+     Elevation Cutoff Setting : 0 deg
+     Date Installed           : 2019-04-15T12:00Z
+     Date Removed             : 2019-10-01T16:00Z
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.3 Receiver Type            : SEPT POLARX5
+     Satellite System         : GPS+GLO+GAL+BDS+SBAS
+     Serial Number            : 3013312
+     Firmware Version         : 5.3.0
+     Elevation Cutoff Setting : 0 deg
+     Date Installed           : 2019-10-01T16:00Z
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Temperature Stabiliz.    : none
+     Additional Information   : L2C disabled
+
+3.x  Receiver Type            : (A20, from rcvr_ant.tab; see instructions)
+     Satellite System         : (GPS+GLO+GAL+BDS+QZSS+SBAS)
+     Serial Number            : (A20, but note the first A5 is used in SINEX)
+     Firmware Version         : (A11)
+     Elevation Cutoff Setting : (deg)
+     Date Installed           : (CCYY-MM-DDThh:mmZ)
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Temperature Stabiliz.    : (none or tolerance in degrees C)
+     Additional Information   : (multiple lines)
+
+
+4.   GNSS Antenna Information
+
+4.1  Antenna Type             : AERAT2775_43    SPKE
+     Serial Number            : 5546
+     Antenna Reference Point  : TOP
+     Marker->ARP Up Ecc. (m)  : 000.0500
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : SPKE
+     Radome Serial Number     : NONE
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2008-07-15T00:00Z
+     Date Removed             : 2009-10-15T20:00Z
+     Additional Information   : 
+
+4.2  Antenna Type             : TRM55971.00     NONE
+     Serial Number            : 1440911917
+     Antenna Reference Point  : BAM
+     Marker->ARP Up Ecc. (m)  : 000.0000
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : NONE
+     Radome Serial Number     : 
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2009-10-15T20:00Z
+     Date Removed             : 2012-01-24T12:00Z
+     Additional Information   : 
+
+4.3  Antenna Type             : TRM57971.00     NONE
+     Serial Number            : 1441112501
+     Antenna Reference Point  : BAM
+     Marker->ARP Up Ecc. (m)  : 000.0000
+     Marker->ARP North Ecc(m) : 000.0000
+     Marker->ARP East Ecc(m)  : 000.0000
+     Alignment from True N    : 0 deg
+     Antenna Radome Type      : NONE
+     Radome Serial Number     : 
+     Antenna Cable Type       : 
+     Antenna Cable Length     : 30.0 m
+     Date Installed           : 2012-01-24T12:00Z
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Additional Information   : 
+
+4.x  Antenna Type             : (A20, from rcvr_ant.tab; see instructions)
+     Serial Number            : (A*, but note the first A5 is used in SINEX)
+     Antenna Reference Point  : (BPA/BCR/XXX from "antenna.gra"; see instr.)
+     Marker->ARP Up Ecc. (m)  : (F8.4)
+     Marker->ARP North Ecc(m) : (F8.4)
+     Marker->ARP East Ecc(m)  : (F8.4)
+     Alignment from True N    : (deg; + is clockwise/east)
+     Antenna Radome Type      : (A4 from rcvr_ant.tab; see instructions)
+     Radome Serial Number     : 
+     Antenna Cable Type       : (vendor & type number)
+     Antenna Cable Length     : (m)
+     Date Installed           : (CCYY-MM-DDThh:mmZ)
+     Date Removed             : (CCYY-MM-DDThh:mmZ)
+     Additional Information   : (multiple lines)
+    """,
+    "utf-8",
+)

--- a/tests/test_igslog.py
+++ b/tests/test_igslog.py
@@ -1,0 +1,73 @@
+import unittest
+import numpy as _np
+import pandas as _pd
+
+from gnssanalysis.gn_io import igslog
+from test_datasets.sitelog_test_data import abmf_site_log_v1 as v1_data, abmf_site_log_v2 as v2_data
+
+
+class Testregex(unittest.TestCase):
+    def test_determine_log_version(self):
+        # Ensure version 1 and 2 strings are produced as expected
+        self.assertEqual(igslog.determine_log_version(v1_data), "v1.0")
+        self.assertEqual(igslog.determine_log_version(v2_data), "v2.0")
+
+    def test_extract_id_block(self):
+        # Ensure the extract of ID information works and gives correct dome number:
+        self.assertEqual(igslog.extract_id_block(v1_data, "/example/path", "ABMF", "v1.0"), ["ABMF", "97103M001"])
+        self.assertEqual(igslog.extract_id_block(v2_data, "/example/path", "ABMF", "v2.0"), ["ABMF", "97103M001"])
+
+    def test_extract_location_block(self):
+
+        # Version 1 Location description results:
+        v1_location_block = igslog.extract_location_block(v1_data, "/example/path", "v1.0")
+        self.assertEqual(v1_location_block.group(1), b"Les Abymes")
+        self.assertEqual(v1_location_block.group(2), b"Guadeloupe")
+
+        # Version 2 Location description results:
+        v2_location_block = igslog.extract_location_block(v2_data, "/example/path", "v2.0")
+        self.assertEqual(v2_location_block.group(1), b"Les Abymes")
+        self.assertEqual(v2_location_block.group(2), b"GLP")
+
+        # Coordinate information remains the same:
+        self.assertEqual(v2_location_block.group(3), v1_location_block.group(3))
+
+    def test_extract_receiver_block(self):
+
+        # Testing version 1:
+        v1_receiver_block = igslog.extract_receiver_block(v1_data, "/example/path")
+        self.assertEqual(v1_receiver_block[0][0], b"LEICA GR25")
+        self.assertEqual(
+            v1_receiver_block[1][0], v1_receiver_block[2][0]
+        )  # Testing that entries [1] and [2] are receiver: "SEPT POLARX5"
+        self.assertEqual(v1_receiver_block[1][3], b"5.2.0")  # Difference between entries is a Firmware change
+        self.assertEqual(v1_receiver_block[2][3], b"5.3.0")  # Difference between entries is a Firmware change
+        # Last receiver should not have an end date assigned (i.e. current):
+        self.assertEqual(v1_receiver_block[-1][-1], b"")
+
+        # Same as above, but for version 2:
+        v2_receiver_block = igslog.extract_receiver_block(v2_data, "/example/path")
+        self.assertEqual(v2_receiver_block[0][0], b"LEICA GR25")
+        self.assertEqual(
+            v2_receiver_block[1][0], v2_receiver_block[2][0]
+        )  # Testing that entries 2 and 3 are "SEPT POLARX5"
+        self.assertEqual(v2_receiver_block[1][3], b"5.2.0")  # Difference between entries 2 and 3 is in Firmware change
+        self.assertEqual(v2_receiver_block[2][3], b"5.3.0")
+        # Last receiver should not have an end date assigned (i.e. current):
+        self.assertEqual(v2_receiver_block[-1][-1], b"")
+
+    def test_extract_antenna_block(self):
+
+        # Testing version 1:
+        v1_antenna_block = igslog.extract_antenna_block(v1_data, "/example/path")
+        self.assertEqual(v1_antenna_block[0][0], b"AERAT2775_43")  # Check antenna type of first entry
+        self.assertEqual(v1_antenna_block[0][8], b"2009-10-15T20:00Z")  # Check end date of second entry
+        # Last antenna should not have an end date assigned (i.e. current):
+        self.assertEqual(v1_antenna_block[-1][-1], b"")
+
+        # Testing version 2:
+        v2_antenna_block = igslog.extract_antenna_block(v2_data, "/example/path")
+        self.assertEqual(v2_antenna_block[0][0], b"AERAT2775_43")  # Check antenna type of first entry
+        self.assertEqual(v2_antenna_block[0][8], b"2009-10-15T20:00Z")  # Check end date of second entry
+        # Last antenna should not have an end date assigned (i.e. current):
+        self.assertEqual(v2_antenna_block[-1][-1], b"")

--- a/tests/test_igslog.py
+++ b/tests/test_igslog.py
@@ -11,11 +11,19 @@ class Testregex(unittest.TestCase):
         # Ensure version 1 and 2 strings are produced as expected
         self.assertEqual(igslog.determine_log_version(v1_data), "v1.0")
         self.assertEqual(igslog.determine_log_version(v2_data), "v2.0")
+        # Check that LogVersionError is raised on wrong data
+        self.assertRaises(igslog.LogVersionError, igslog.determine_log_version, b"Wrong data")
 
     def test_extract_id_block(self):
         # Ensure the extract of ID information works and gives correct dome number:
         self.assertEqual(igslog.extract_id_block(v1_data, "/example/path", "ABMF", "v1.0"), ["ABMF", "97103M001"])
         self.assertEqual(igslog.extract_id_block(v2_data, "/example/path", "ABMF", "v2.0"), ["ABMF", "97103M001"])
+        # Check that automatic version determination works as expected:
+        self.assertEqual(igslog.extract_id_block(v1_data, "/example/path", "ABMF"), ["ABMF", "97103M001"])
+        # Check that LogVersionError is raised on wrong data
+        self.assertRaises(igslog.LogVersionError, igslog.extract_id_block, b"Wrong data", "/example/path", "ABMF")
+        # Check that LogVersionError is raised on wrong version number
+        self.assertRaises(igslog.LogVersionError, igslog.extract_id_block, v1_data, "/example/path", "ABMF", "v3.0")
 
     def test_extract_location_block(self):
 


### PR DESCRIPTION
A quick PR to update the code to handle new metadata fields in IGS log files.

This will still be able to read and process the old IGS log files as well (backwards compatible)