### PR TITLE
NPI-3683 SP3 consistency check streamlining

### DIFF
--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -30,8 +30,10 @@ _RE_SP3_HEAD = _re.compile(
 )
 
 _RE_SP3_COMMENT_STRIP = _re.compile(rb"^(\/\*.*$\n)", _re.MULTILINE)
+
 # Regex to extract Satellite Vehicle (SV) names (E.g. G02). In SP3-d (2016) up to 999 satellites can be included).
 # Regex options/flags: multiline, findall. Updated to extract expected SV count too.
+# Note this extracts both the stated number of SVs AND the actual SV names.
 _RE_SP3_HEADER_SV = _re.compile(rb"^\+[ ]+([\d]+|)[ ]+((?:[A-Z]\d{2})+)\W", _re.MULTILINE)
 
 # Regex for orbit accuracy codes (E.g. ' 15' - space padded, blocks are three chars wide).
@@ -184,6 +186,7 @@ def sp3_pos_nodata_to_nan(sp3_df: _pd.DataFrame) -> None:
 def sp3_clock_nodata_to_nan(sp3_df: _pd.DataFrame) -> None:
     """
     Converts the SP3 Clock column's nodata values (999999 or 999999.999999 - fractional component optional) to NaNs.
+    Operates on the DataFrame in place.
     See https://files.igs.org/pub/data/format/sp3_docu.txt
 
     :param _pd.DataFrame sp3_df: SP3 data frame to filter nodata values for

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -227,6 +227,7 @@ def remove_offline_sats(sp3_df: _pd.DataFrame, df_friendly_name: str = ""):
     Remove any satellites that have "0.0" or NaN for all three position coordinates - this indicates satellite offline.
     Note that this removes a satellite which has *any* missing coordinate data, meaning a satellite with partial
     observations will get removed entirely.
+    Note: the internal representation of the SP3 header will be updated to reflect the removal.
     Added in version 0.0.57
 
     :param _pd.DataFrame sp3_df: SP3 DataFrame to remove offline / nodata satellites from.
@@ -255,8 +256,7 @@ def remove_offline_sats(sp3_df: _pd.DataFrame, df_friendly_name: str = ""):
 
     # Using that list of offline / partially offline sats, remove all entries for those sats from the SP3 DataFrame:
     sp3_df = sp3_df.drop(offline_sats, level=1, errors="ignore")
-    # TODO should the following be removed?!:
-    sp3_df.attrs["HEADER"].HEAD.ORB_TYPE = "INT"  # Allow the file to be read again by read_sp3 - File ORB_TYPE changes
+
     if len(offline_sats) > 0:
         # Update the internal representation of the SP3 header to match the change
         remove_svs_from_header(sp3_df, offline_sats.values)

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -302,7 +302,7 @@ def filter_by_svs(
 
     # Disqualify SVs unless the match the given names
     if filter_by_name:
-        keep_set.intersection(filter_by_name)
+        keep_set = keep_set.intersection(filter_by_name)
 
     # Disqualify SVs unless they match a given constellation letter (i.e. 'G', 'E', 'R', 'C')
     if filter_to_sat_letter:
@@ -311,8 +311,8 @@ def filter_by_svs(
                 "Name of sat constellation to filter to, must be a single char. E.g. you cannot enter 'GE'"
             )
         # Make set of every SV name in the constellation we're keeping
-        constellation_sats_to_keep = [sv for sv in all_sv_names if filter_to_sat_letter.upper() in sv]
-        keep_set.intersection(constellation_sats_to_keep)
+        constellation_sats_to_keep = set([sv for sv in all_sv_names if filter_to_sat_letter.upper() in sv])
+        keep_set = keep_set.intersection(constellation_sats_to_keep)
 
     # Drop SVs beyond n (i.e. keep only the first n SVs)
     if filter_by_count:

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -751,6 +751,22 @@ def parse_sp3_header(header: bytes, warn_on_negative_sv_acc_values: bool = True)
                 "SV_COUNT_STATED",  # (Here for convenience) parsed earlier with _RE_SP3_HEADER_SV, not by above regex
             ],
         )
+        # SP3 file versions:
+        # - a: Oct 1995 - Single constellation.
+        # - b: Oct 1998 - Adds GLONASS support.
+        # - c: ~2006 to Aug 2010 - Appears to add multiple new constellations, Japan's QZSS added in 2010.
+        # - d: Feb 2016 - Max number of satellites raised from 85 to 999.
+
+        header_version = str(header_array[0])
+        if header_version in ("a", "b"):
+            logger.warning(f"SP3 file is old version: '{header_version}', you may experience parsing issues")
+        elif header_version in ("c", "d"):
+            logger.info(f"SP3 header states SP3 file version is: {header_array[0]}")
+        else:
+            logger.warning(
+                f"SP3 header is of an unknown version, or failed to parse! Version appears to be: '{header_version}'"
+            )
+
     except AttributeError as e:  # Make the exception slightly clearer.
         raise AttributeError("Failed to parse SP3 header. Regex likely returned no match.", e)
 

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -859,19 +859,21 @@ def get_unique_svs(sp3_df: _pd.DataFrame) -> _pd.Index:
     """
 
     # Are we dealing with a DF which is early in processing: with Position, Velocity, and EV / EP rows in it?
-    # This will have the PV_FLAG index level. It *may* contain EV / EP rows, though until we support these they
-    # should be promptly removed at that point.
-    # Alternativley, has this DF had Position and Velocity data merged (into columns, not interlaced rows).
-    # In this case the PV_FLAG index level will have been dropped.
+    # -> This will have the PV_FLAG index level. It *may* contain EV / EP rows, though until we support these they
+    #    should be promptly removed at that point.
+
+    # Alternativley, has this DF had Position and Velocity data merged (into columns, not interlaced rows)?
+    # -> In this case the PV_FLAG index level will have been dropped.
     if "PV_FLAG" in sp3_df.index.names:
         if "E" in sp3_df.index.get_level_values("PV_FLAG").unique():
             logger.warning(
                 "EV/EP record found late in SP3 processing. Until we actually support them, "
                 "they should be removed by the EV/EP check earlier on! Filtering out while determining unique SVs."
             )
-            # Filter on data that doesn't relate to EV / EP rows
+            # Filter to data that doesn't relate to EV / EP rows, then get SVs from index (level 1).
             return sp3_df.loc[sp3_df.index.get_level_values("PV_FLAG") != "E"].index.get_level_values(1).unique()
 
+    # Get index values from level 1 (which is SVs)
     return sp3_df.index.get_level_values(1).unique()
 
 

--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -292,7 +292,7 @@ def filter_by_svs(
     """
 
     # Get all SV names
-    all_sv_names = sp3_df.index.get_level_values(1).unique().array
+    all_sv_names = get_unique_svs(sp3_df)
     total_svs = len(all_sv_names)
     logger.info(f"Total SVs: {total_svs}")
 
@@ -427,7 +427,7 @@ def check_epoch_counts_for_discrepancies(
         sp3_filename = try_get_sp3_filename(sp3_path_or_bytes)
 
     # Could potentially check has_duplicates first for speed?
-    content_unique_epoch_count = draft_sp3_df.index.get_level_values(0).unique().size
+    content_unique_epoch_count = get_unique_epochs(draft_sp3_df).size
     # content_total_epoch_count = draft_sp3_df.index.get_level_values(0).size
 
     header_epoch_count = int(parsed_sp3_header.HEAD.N_EPOCHS)
@@ -920,7 +920,7 @@ def gen_sp3_header(sp3_df: _pd.DataFrame) -> str:
     # Check that number of SVs the header metadata says should be here, matches the number of SVs *listed* in
     # header metadata (which we use to output the new header). Then check that this in turn matches the number of
     # unique SVs in the SP3 DataFrame itself.
-    dataframe_sv_count = sp3_df.index.get_level_values(1).unique().size
+    dataframe_sv_count = get_unique_svs(sp3_df).size
     header_sv_stated_count = int(head["SV_COUNT_STATED"])
     header_sv_actual_count = int(n_sats)
 

--- a/tests/test_sp3.py
+++ b/tests/test_sp3.py
@@ -138,6 +138,19 @@ class TestSp3(unittest.TestCase):
             "Header says there should be 1 epochs, however there are 2 (unique) epochs in the content (duplicate epoch check comes later).",
             "Loading SP3 with mismatch between SV count in header and in content, should raise exception",
         )
+    
+    @patch("builtins.open", new_callable=mock_open, read_data=sp3c_example2_data)
+    def test_read_sp3_correct_svs_read_when_ev_ep_present(self, mock_file):
+        # This should not raise an exception; SV count should match header if parsed correctly.
+        result = sp3.read_sp3(
+            "testfile.SP3",
+            pOnly=False,
+            check_header_vs_filename_vs_content_discrepancies=True,  # Actually enable the checks for this one
+            skip_filename_in_discrepancy_check=True,
+        )
+        parsed_svs_content = sp3.get_unique_svs(result).astype(str).values
+        self.assertEqual(set(parsed_svs_content), set(["G01", "G02", "G03", "G04", "G05"]))
+
     # TODO Add test(s) for correctly reading header fundamentals (ACC, ORB_TYPE, etc.)
     # TODO add tests for correctly reading the actual content of the SP3 in addition to the header.
     # TODO add tests for correctly generating sp3 output content with gen_sp3_content() and gen_sp3_header()


### PR DESCRIPTION
This PR adds various restructuring of the SP3 read and validation process, aimed at improving consistency and separating concerns better between stages of the process.

Also:
- Stopped setting header `ORB_TYPE` to `INT` when removing offline sats.
- Added utility functions to derive unique epochs and SVs, to capture the nuances in a single place.
- Added `remove_svs_from_header()` utility function for removing sats from internal header, so we can better maintain header consistency when performing operations like `remove_offline_sats()`
- Improved `filter_by_svs()`, reworking the removal logic to only call `drop()` once, and to update the internal header to reflect the new list of sats.
- Added experimental detection and warnings for old / new versions of SP3 format.