### PR TITLE
NPI-3793 Fix misleading operator use on sets

### DIFF
--- a/gnssanalysis/gn_diffaux.py
+++ b/gnssanalysis/gn_diffaux.py
@@ -472,7 +472,7 @@ def sisre(
         _logging.info(msg="plotting RAC difference")
         _gn_plot.racplot(rac_unstack=rac_unstack, output=plot if isinstance(plot, str) else None)
 
-    if (clk_a is not None) & (clk_b is not None):  # check if clk data is present
+    if (clk_test is not None) and (clk_baseline is not None):  # check if clk data is present
         clk_diff = (
             compare_clk(
                 clk_a, clk_b, norm_types=norm_types, ext_dt=rac_unstack.index, ext_svs=rac_unstack.columns.levels[1]

--- a/gnssanalysis/gn_io/sinex.py
+++ b/gnssanalysis/gn_io/sinex.py
@@ -845,7 +845,7 @@ def llh2snxdms(llh):
     ll_stack = _pd.concat([llh_degminsec_df.LON, llh_degminsec_df.LAT], axis=0)
     ll_stack = ll_stack.D.str.rjust(4).values + ll_stack.M.str.rjust(3).values + ll_stack.S.str.rjust(5).values
     buf = ll_stack[:n_rows] + ll_stack[n_rows:] + llh_degminsec_df.HEI.str.rjust(8).values
-
+    # The following is a Numpy OR operator (not a standard Python bitwise OR):
     buf[(height > 8000) | (height < -2000)] = " 000 00 00.0  00 00 00.0   000.0"  # | zero_mask
     return buf
 

--- a/gnssanalysis/gn_utils.py
+++ b/gnssanalysis/gn_utils.py
@@ -467,7 +467,7 @@ def log2snx(logglob, rnxglob, outfile, frame_snx, frame_dis, frame_psd, datetime
     from .gn_io import igslog
 
     if isinstance(rnxglob, list):
-        if (len(rnxglob) == 1) & (
+        if (len(rnxglob) == 1) and (
             rnxglob[0].find("*") != -1
         ):  # it's rnx_glob expression (may be better to check if star is present)
             rnxglob = rnxglob[0]


### PR DESCRIPTION
There are some instances where a bitwise AND operator appears to be used on structures for which it does not make sense.

Plus add clarifying comment for some Numpy custom operator usage.

This PR was split out from work done to restructure clk comparison and sisre calculation. TODO: a small fix is needed.
