### PR TITLE
NPI-3973 Fix bug in specification of stypes

### DIFF
--- a/gnssanalysis/gn_io/sinex.py
+++ b/gnssanalysis/gn_io/sinex.py
@@ -771,7 +771,7 @@ def _get_snx_vector_gzchunks(filename: str, block_name="SOLUTION/ESTIMATE", size
                     stop = True
             i += 1
 
-    return _get_snx_vector(path_or_bytes=block_bytes, stypes=set("EST"), format=format)
+    return _get_snx_vector(path_or_bytes=block_bytes, stypes=set(["EST"]), format=format)
 
 
 def _get_snx_id(path):


### PR DESCRIPTION
Set containing a single string, mistakenly defined as a set of characters within that string. This is likely causing valid stypes to be rejected.