### PR TITLE
NPI-4062 - Produce empty list when no sats detected in NANUS

### DIFF
--- a/gnssanalysis/gn_io/nanu.py
+++ b/gnssanalysis/gn_io/nanu.py
@@ -145,7 +145,7 @@ def get_bad_sv_from_nanu_df(nanu_df: _pd.DataFrame, datetime: _Union[_np.datetim
     ]
 
     if last_selected.empty:
-        return None
+        return []
 
     _logging.info(msg="NANUs in affect are:\n" + "\n".join(last_selected.FILEPATH.to_list()))
 


### PR DESCRIPTION
A simple fix: Return empty list when no bad sats detected from nanus, rather than `None`.
This will resolve an issue we are seeing in Ginan-ops