### PR TITLE
NPI-4066 Reject SP3 files with overlong data lines

### DIFF
--- a/gnssanalysis/gn_io/sp3.py
+++ b/gnssanalysis/gn_io/sp3.py
@@ -64,6 +64,8 @@ _RE_SP3_HEADER_ACC = _re.compile(rb"^\+{2}[ ]+((?:[\-\d\s]{2}\d){17})\W", _re.MU
 # File descriptor and clock
 _RE_SP3_HEAD_FDESCR = _re.compile(rb"\%c[ ]+(\w{1})[ ]+cc[ ](\w{3})")
 
+# Max width of SP3 lines
+_SP3_MAX_WIDTH: int = 80
 
 _SP3_DEF_PV_WIDTH = [1, 3, 14, 14, 14, 14, 1, 2, 1, 2, 1, 2, 1, 3, 1, 1, 1, 2, 1, 1]
 _SP3_DEF_PV_NAME = [
@@ -866,6 +868,19 @@ def read_sp3(
     # Note: this interpretation is based on page 16 of the SP3d spec, which says 'The comment lines should be read in
     # until the first Epoch Header Record (i.e. the first time tag line) is encountered.'
     # For robustness we strip comments THROUGHOUT the data before continuing parsing.
+
+    # Check no (non-comment) line is overlong (>80 chars not counting \n)
+    sp3_lines: List[str] = content.decode("utf-8", errors="ignore").split("\n")
+    overlong_lines_found: int = 0
+    for line in sp3_lines:
+        if len(line) > _SP3_MAX_WIDTH:
+            overlong_lines_found += 1
+            logger.error(f"Line of SP3 input exceeded max width: '{line}'")
+
+    if overlong_lines_found > 0:
+        raise ValueError(
+            f"{overlong_lines_found} SP3 epoch data lines were overlong and very likely to parse incorrectly."
+        )
 
     # NOTE: We just stripped all comment lines from the input data, so the %i records are now the last thing in the
     # header before the first Epoch Header Record.

--- a/tests/test_sp3.py
+++ b/tests/test_sp3.py
@@ -197,6 +197,27 @@ class TestSP3(unittest.TestCase):
     # TODO Add test(s) for correctly reading header fundamentals (ACC, ORB_TYPE, etc.)
     # TODO add tests for correctly reading the actual content of the SP3 in addition to the header.
 
+    def test_read_sp3_overlong_lines(self):
+        """
+        Test overlong content line check
+        """
+
+        test_content_no_overlong: bytes = b"""#dV2007  4 12  0  0  0.00000000       2 ORBIT IGS14 BHN ESOC
+## 1422 345600.00000000   900.00000000 54202 0.0000000000000 THIS LINE IS TOO LONG
++    2   G01G02  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 THIS IS OK.........
++    2   G01G02  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 TOO LONG AGAIN ......
+"""
+        #         test_content_no_overlong: bytes = b"""#dV2007  4 12  0  0  0.00000000       2 ORBIT IGS14 BHN ESOC
+        # +    2   G01G02  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 THIS IS OK.........
+        # """
+
+        # sp3.read_sp3(test_content_no_overlong)
+        with self.assertRaises(ValueError) as read_exception:
+            sp3.read_sp3(test_content_no_overlong)
+            self.assertEqual(
+                read_exception.msg, "2 SP3 epoch data lines were overlong and very likely to parse incorrectly."
+            )
+
     @staticmethod
     def get_example_dataframe(template_name: str = "normal", include_simple_header: bool = True) -> pd.DataFrame:
 
@@ -295,7 +316,7 @@ class TestSP3(unittest.TestCase):
                 [
                     "d",
                     "P",
-                    "Time TODO",
+                    "Time TODO",  # TODO
                     "3",  # Num epochs
                     "Data TODO",
                     "coords TODO",


### PR DESCRIPTION
SP3 data lines are fixed width and strictly follow a columnar layout. Misaligned data can lead to serious parsing issues, including grossly incorrect position values.

This PR adds a simple check to `read_sp3()`, rejecting any SP3 data which has line(s) exceeding 80 chars.

Further work is in train to more robustly check alignment by testing that all unused columns contain a space.